### PR TITLE
feat: área do consultor

### DIFF
--- a/docs/FRONTEND_API_GUIDE.md
+++ b/docs/FRONTEND_API_GUIDE.md
@@ -16,11 +16,12 @@ Este documento fornece uma referência completa da API REST para desenvolvedores
 10. [Endpoints de Transações](#endpoints-de-transações)
     11. [Endpoints de Cartões de Crédito](#endpoints-de-cartões-de-crédito)
     12. [Endpoints de Metas (Goals)](#endpoints-de-metas-goals)
-    13. [Endpoints de Simulação Financeira](#endpoints-de-simulação-financeira)
-    14. [Endpoints de Chat/AI](#endpoints-de-chatai)
-    15. [Endpoints de WhatsApp Connections](#endpoints-de-whatsapp-connections)
-    16. [Tratamento de Erros](#tratamento-de-erros)
-    17. [Exemplos de Uso](#exemplos-de-uso)
+    13. [Endpoints da Área do Consultor](#endpoints-da-área-do-consultor)
+    14. [Endpoints de Simulação Financeira](#endpoints-de-simulação-financeira)
+    15. [Endpoints de Chat/AI](#endpoints-de-chatai)
+    16. [Endpoints de WhatsApp Connections](#endpoints-de-whatsapp-connections)
+    17. [Tratamento de Erros](#tratamento-de-erros)
+    18. [Exemplos de Uso](#exemplos-de-uso)
 
 ---
 
@@ -168,7 +169,7 @@ export interface LoginResponse {
 export interface User {
   id: string;
   email: string;
-  role: 'owner' | 'member';
+  role: 'owner' | 'member' | 'consultant';  // consultant = plan consultant_basic/pro/premium
   created_at: string;
   subscription?: {
     plan: 'free' | 'beta' | 'premium';
@@ -252,6 +253,126 @@ export interface CreateWhatsAppConnectionRequest {
 export interface ListWhatsAppConnectionsResponse {
   total: number;
   connections: WhatsAppConnection[];
+}
+
+// ===== CONSULTANT DASHBOARD =====
+export interface ConsultantConsolidatedSummaryResponse {
+  total_income: number;
+  total_expenses: number;
+  balance: number;
+  total_transactions: number;
+  organizations_count: number;
+  period_start: string | null;
+  period_end: string | null;
+}
+
+export interface ConsultantClient {
+  organization_id: string;
+  organization_name: string;
+  role: 'owner' | 'member';
+  membership_created_at: string;
+}
+
+export interface ListConsultantClientsResponse {
+  total: number;
+  clients: ConsultantClient[];
+}
+
+export interface FinancialHealthIndexResponse {
+  index: number;
+  balance_score: number;
+  debt_score: number;
+  reserve_score: number;
+  total_income: number;
+  total_expenses: number;
+  balance: number;
+  total_debt: number;
+  organizations_count: number;
+  period_start: string;
+  period_end: string;
+  formula_info: string;
+}
+
+export interface ActiveGoalsCountResponse {
+  active_goals_count: number;
+  organizations_count: number;
+  as_of_date: string;
+}
+
+export interface TotalCreditCardDebtResponse {
+  total_debt: number;
+  organizations_count: number;
+  as_of_date: string;
+}
+
+export interface MonthlyCashFlowItem {
+  month: string;
+  year: number;
+  month_number: number;
+  total_income: number;
+  total_expenses: number;
+  balance: number;
+}
+
+export interface CashFlowResponse {
+  monthly_data: MonthlyCashFlowItem[];
+  period_start: string;
+  period_end: string;
+}
+
+export interface CategoryExpenseItem {
+  name: string;
+  total: number;
+  percentage: number;
+}
+
+export interface ExpensesByCategoryResponse {
+  categories: CategoryExpenseItem[];
+  total_expenses: number;
+  period_start: string;
+  period_end: string;
+}
+
+export interface MonthlyIncomeCommitmentItem {
+  month: string;
+  year: number;
+  month_number: number;
+  income_commitment_percent: number;
+  total_income: number;
+  total_card_bills: number;
+}
+
+export interface IncomeCommitmentResponse {
+  monthly_data: MonthlyIncomeCommitmentItem[];
+  period_start: string;
+  period_end: string;
+}
+
+export interface GoalProgressByTypeItem {
+  goal_name: string;
+  avg_progress: number;
+  count: number;
+}
+
+export interface GoalsProgressByTypeResponse {
+  by_type: GoalProgressByTypeItem[];
+  organizations_count: number;
+  as_of_date: string;
+}
+
+export interface ClientAtRiskItem {
+  organization_id: string;
+  organization_name: string;
+  main_situation: string;
+  current_balance: number;
+  last_invoice_status: string;
+  risk_score: number;
+}
+
+export interface ClientsAtRiskResponse {
+  clients: ClientAtRiskItem[];
+  total: number;
+  as_of_date: string;
 }
 
 // ===== USUÁRIOS =====
@@ -646,6 +767,8 @@ const login = async (email: string, password: string): Promise<LoginResponse> =>
 
 Retorna informações do usuário autenticado.
 
+**Campo `role`:** `"owner"` | `"member"` | `"consultant"`. Usuários com plano de consultoria (consultant_basic, consultant_pro, etc.) retornam `"consultant"` em vez de owner/member.
+
 **Request:**
 ```typescript
 const getCurrentUser = async (): Promise<User> => {
@@ -767,7 +890,7 @@ const registerMember = async (
 
 ### GET `/v1/users/me`
 
-Retorna o perfil do usuário autenticado (mesmo que `/v1/auth/me`).
+Retorna o perfil do usuário autenticado (mesmo que `/v1/auth/me`). O campo `role` retorna `"consultant"` para usuários com plano de consultoria.
 
 **Request:**
 ```typescript
@@ -1039,50 +1162,6 @@ const listTagTypes = async (): Promise<TagTypesResponse> => {
 
 **Erros:**
 - `500`: Erro interno do servidor
-
-### POST `/v1/tag-types`
-
-Cria um novo tipo de tag no sistema.
-
-**Request:**
-```typescript
-const createTagType = async (data: CreateTagTypeRequest): Promise<TagType> => {
-  const response = await apiClient.post<TagType>('/v1/tag-types', data);
-  return response.data;
-};
-
-// CreateTagTypeRequest
-{
-  name: string;           // Ex: "categoria", "projeto"
-  description?: string;   // Opcional
-  is_required?: boolean;  // Default: false
-  max_per_transaction?: number | null;  // null = ilimitado
-}
-```
-
-**Response (201):** Retorna o `TagType` criado.
-
-**Erros:**
-- `400`: Dados inválidos ou nome duplicado
-- `403`: Sem permissão
-
-### PATCH `/v1/tag-types/{tag_type_id}`
-
-Atualiza um tipo de tag existente.
-
-**Request:** Mesmo body do POST (campos opcionais).
-
-**Erros:**
-- `404`: Tipo não encontrado
-- `400`: Dados inválidos
-
-### DELETE `/v1/tag-types/{tag_type_id}`
-
-Remove um tipo de tag. Pode falhar se houver tags vinculadas.
-
-**Erros:**
-- `404`: Tipo não encontrado
-- `409`: Existem tags vinculadas a este tipo
 
 ---
 
@@ -2911,6 +2990,719 @@ await updateGoal("goal-uuid", "org-uuid", {
 
 ---
 
+## 👔 Endpoints da Área do Consultor
+
+Endpoints exclusivos para usuários com perfil de **consultor**, que gerenciam múltiplas organizações (clientes). Requer autenticação e feature flags habilitadas (`multi_org_dashboard`, `client_list`, `consolidated_reports`).
+
+### GET `/v1/consultant/summary`
+
+Resumo consolidado de todas as organizações do consultor (multi_org_dashboard).
+
+**Request:**
+```typescript
+interface ConsultantSummaryQuery {
+  date_start?: string;  // YYYY-MM-DD (opcional)
+  date_end?: string;    // YYYY-MM-DD (opcional)
+}
+
+interface ConsultantSummaryResponse {
+  total_income: number;
+  total_expenses: number;
+  balance: number;
+  total_transactions: number;
+  organizations_count: number;
+  period_start: string | null;  // YYYY-MM-DD
+  period_end: string | null;    // YYYY-MM-DD
+}
+
+const getConsultantSummary = async (
+  params?: ConsultantSummaryQuery
+): Promise<ConsultantSummaryResponse> => {
+  const response = await apiClient.get<ConsultantSummaryResponse>(
+    '/v1/consultant/summary',
+    { params }
+  );
+  return response.data;
+};
+```
+
+**Exemplo:**
+```typescript
+// Resumo do período atual (padrão)
+const summary = await getConsultantSummary();
+
+// Resumo de um período específico
+const janSummary = await getConsultantSummary({
+  date_start: '2025-01-01',
+  date_end: '2025-01-31'
+});
+console.log(`Balanço: ${janSummary.balance}, Clientes: ${janSummary.organizations_count}`);
+```
+
+**Response (200):**
+```typescript
+{
+  total_income: 50000.00,
+  total_expenses: 32000.00,
+  balance: 18000.00,
+  total_transactions: 245,
+  organizations_count: 8,
+  period_start: "2025-01-01",
+  period_end: "2025-01-31"
+}
+```
+
+**Erros:**
+- `401`: Não autenticado
+- `403`: Usuário não é consultor ou feature `multi_org_dashboard` ausente
+- `500`: `CONSULTANT_SERVICE_ERROR` - Erro interno do serviço (ex.: falha ao buscar memberships)
+
+---
+
+### GET `/v1/consultant/clients`
+
+Lista de clientes (organizações) vinculados ao consultor (client_list).
+
+**Request:**
+```typescript
+interface ConsultantClient {
+  organization_id: string;
+  organization_name: string;
+  role: 'owner' | 'member';  // Role in that organization (membership), not consultant
+  membership_created_at: string;  // ISO 8601
+}
+
+interface ConsultantClientsResponse {
+  total: number;
+  clients: ConsultantClient[];
+}
+
+const getConsultantClients = async (): Promise<ConsultantClientsResponse> => {
+  const response = await apiClient.get<ConsultantClientsResponse>(
+    '/v1/consultant/clients'
+  );
+  return response.data;
+};
+```
+
+**Exemplo:**
+```typescript
+const { total, clients } = await getConsultantClients();
+clients.forEach((c) => {
+  console.log(`${c.organization_name} (${c.role}) - desde ${c.membership_created_at}`);
+});
+```
+
+**Response (200):**
+```typescript
+{
+  total: 8,
+  clients: [
+    {
+      organization_id: "123e4567-e89b-12d3-a456-426614174000",
+      organization_name: "Empresa ABC",
+      role: "owner",
+      membership_created_at: "2024-06-15T10:00:00Z"
+    },
+    {
+      organization_id: "223e4567-e89b-12d3-a456-426614174001",
+      organization_name: "Empresa XYZ",
+      role: "member",
+      membership_created_at: "2024-08-20T14:30:00Z"
+    }
+  ]
+}
+```
+
+**Erros:**
+- `401`: Não autenticado
+- `403`: Usuário não é consultor ou feature `client_list` ausente
+- `500`: `CONSULTANT_SERVICE_ERROR` - Erro interno do serviço (ex.: falha ao buscar memberships)
+
+---
+
+### GET `/v1/consultant/reports/consolidated`
+
+Relatório consolidado de todas as organizações do consultor (consolidated_reports). Mesmo formato de resposta do summary.
+
+**Request:**
+```typescript
+interface ConsultantReportQuery {
+  date_start?: string;  // YYYY-MM-DD (opcional)
+  date_end?: string;    // YYYY-MM-DD (opcional)
+}
+
+const getConsultantConsolidatedReport = async (
+  params?: ConsultantReportQuery
+): Promise<ConsultantSummaryResponse> => {
+  const response = await apiClient.get<ConsultantSummaryResponse>(
+    '/v1/consultant/reports/consolidated',
+    { params }
+  );
+  return response.data;
+};
+```
+
+**Exemplo:**
+```typescript
+const report = await getConsultantConsolidatedReport({
+  date_start: '2025-01-01',
+  date_end: '2025-01-31'
+});
+console.log(`Receitas: ${report.total_income}, Despesas: ${report.total_expenses}`);
+```
+
+**Response (200):**
+```typescript
+{
+  total_income: 50000.00,
+  total_expenses: 32000.00,
+  balance: 18000.00,
+  total_transactions: 245,
+  organizations_count: 8,
+  period_start: "2025-01-01",
+  period_end: "2025-01-31"
+}
+```
+
+**Erros:**
+- `401`: Não autenticado
+- `403`: Usuário não é consultor ou feature `consolidated_reports` ausente
+- `500`: `CONSULTANT_SERVICE_ERROR` - Erro interno do serviço (ex.: falha ao buscar memberships)
+
+---
+
+### GET `/v1/consultant/financial-health-index`
+
+Índice de saúde financeira ponderado (saldo, dívida, reserva) de todas as organizações do consultor.
+
+**Request:**
+```typescript
+interface FinancialHealthIndexQuery {
+  date_start?: string;  // YYYY-MM-DD (opcional)
+  date_end?: string;    // YYYY-MM-DD (opcional)
+}
+
+interface FinancialHealthIndexResponse {
+  index: number;           // 0-100 (índice geral)
+  balance_score: number;   // 0-100 (score de saldo)
+  debt_score: number;      // 0-100 (score de endividamento)
+  reserve_score: number;   // 0-100 (score de reserva)
+  total_income: number;
+  total_expenses: number;
+  balance: number;
+  total_debt: number;
+  organizations_count: number;
+  period_start: string;    // YYYY-MM-DD
+  period_end: string;      // YYYY-MM-DD
+  formula_info: string;    // Descrição da fórmula usada
+}
+
+const getFinancialHealthIndex = async (
+  params?: FinancialHealthIndexQuery
+): Promise<FinancialHealthIndexResponse> => {
+  const response = await apiClient.get<FinancialHealthIndexResponse>(
+    '/v1/consultant/financial-health-index',
+    { params }
+  );
+  return response.data;
+};
+```
+
+**Exemplo:**
+```typescript
+const health = await getFinancialHealthIndex({
+  date_start: '2025-01-01',
+  date_end: '2025-01-31'
+});
+console.log(`Índice de Saúde: ${health.index}/100`);
+console.log(`Score Saldo: ${health.balance_score}, Score Dívida: ${health.debt_score}`);
+```
+
+**Response (200):**
+```typescript
+{
+  index: 72.5,
+  balance_score: 80.0,
+  debt_score: 65.0,
+  reserve_score: 72.5,
+  total_income: 50000.00,
+  total_expenses: 32000.00,
+  balance: 18000.00,
+  total_debt: 8500.00,
+  organizations_count: 8,
+  period_start: "2025-01-01",
+  period_end: "2025-01-31",
+  formula_info: "Média ponderada: 40% saldo, 40% dívida, 20% reserva"
+}
+```
+
+**Erros:**
+- `401`: Não autenticado
+- `403`: Usuário não é consultor ou feature `multi_org_dashboard` ausente
+
+---
+
+### GET `/v1/consultant/active-goals-count`
+
+Contagem de metas ativas em todas as organizações do consultor.
+
+**Request:**
+```typescript
+interface ActiveGoalsCountQuery {
+  as_of_date?: string;  // YYYY-MM-DD (opcional, padrão: hoje)
+}
+
+interface ActiveGoalsCountResponse {
+  active_goals_count: number;
+  organizations_count: number;
+  as_of_date: string;  // YYYY-MM-DD
+}
+
+const getActiveGoalsCount = async (
+  params?: ActiveGoalsCountQuery
+): Promise<ActiveGoalsCountResponse> => {
+  const response = await apiClient.get<ActiveGoalsCountResponse>(
+    '/v1/consultant/active-goals-count',
+    { params }
+  );
+  return response.data;
+};
+```
+
+**Exemplo:**
+```typescript
+const goals = await getActiveGoalsCount();
+console.log(`${goals.active_goals_count} metas ativas em ${goals.organizations_count} clientes`);
+```
+
+**Response (200):**
+```typescript
+{
+  active_goals_count: 15,
+  organizations_count: 8,
+  as_of_date: "2025-01-31"
+}
+```
+
+**Erros:**
+- `401`: Não autenticado
+- `403`: Usuário não é consultor ou feature `multi_org_dashboard` ausente
+
+---
+
+### GET `/v1/consultant/total-credit-card-debt`
+
+Total de dívida de cartão de crédito não paga em todas as organizações do consultor.
+
+**Request:**
+```typescript
+interface TotalCreditCardDebtQuery {
+  as_of_date?: string;  // YYYY-MM-DD (opcional, padrão: hoje)
+}
+
+interface TotalCreditCardDebtResponse {
+  total_debt: number;
+  organizations_count: number;
+  as_of_date: string;  // YYYY-MM-DD
+}
+
+const getTotalCreditCardDebt = async (
+  params?: TotalCreditCardDebtQuery
+): Promise<TotalCreditCardDebtResponse> => {
+  const response = await apiClient.get<TotalCreditCardDebtResponse>(
+    '/v1/consultant/total-credit-card-debt',
+    { params }
+  );
+  return response.data;
+};
+```
+
+**Exemplo:**
+```typescript
+const debt = await getTotalCreditCardDebt();
+console.log(`Dívida total de cartões: R$ ${debt.total_debt}`);
+```
+
+**Response (200):**
+```typescript
+{
+  total_debt: 12500.00,
+  organizations_count: 8,
+  as_of_date: "2025-01-31"
+}
+```
+
+**Erros:**
+- `401`: Não autenticado
+- `403`: Usuário não é consultor ou feature `multi_org_dashboard` ausente
+
+---
+
+### GET `/v1/consultant/cash-flow`
+
+Fluxo de caixa mensal (receitas, despesas, saldo) de todas as organizações do consultor.
+
+**Request:**
+```typescript
+interface CashFlowQuery {
+  date_start?: string;  // YYYY-MM-DD (opcional)
+  date_end?: string;    // YYYY-MM-DD (opcional)
+}
+
+interface MonthlyCashFlowItem {
+  month: string;        // YYYY-MM
+  year: number;
+  month_number: number; // 1-12
+  total_income: number;
+  total_expenses: number;
+  balance: number;
+}
+
+interface CashFlowResponse {
+  monthly_data: MonthlyCashFlowItem[];
+  period_start: string;  // YYYY-MM-DD
+  period_end: string;    // YYYY-MM-DD
+}
+
+const getCashFlow = async (
+  params?: CashFlowQuery
+): Promise<CashFlowResponse> => {
+  const response = await apiClient.get<CashFlowResponse>(
+    '/v1/consultant/cash-flow',
+    { params }
+  );
+  return response.data;
+};
+```
+
+**Exemplo:**
+```typescript
+const cashFlow = await getCashFlow({
+  date_start: '2025-01-01',
+  date_end: '2025-03-31'
+});
+cashFlow.monthly_data.forEach((month) => {
+  console.log(`${month.month}: Receita ${month.total_income}, Despesa ${month.total_expenses}, Saldo ${month.balance}`);
+});
+```
+
+**Response (200):**
+```typescript
+{
+  monthly_data: [
+    {
+      month: "2025-01",
+      year: 2025,
+      month_number: 1,
+      total_income: 50000.00,
+      total_expenses: 32000.00,
+      balance: 18000.00
+    },
+    {
+      month: "2025-02",
+      year: 2025,
+      month_number: 2,
+      total_income: 52000.00,
+      total_expenses: 35000.00,
+      balance: 17000.00
+    }
+  ],
+  period_start: "2025-01-01",
+  period_end: "2025-03-31"
+}
+```
+
+**Erros:**
+- `401`: Não autenticado
+- `403`: Usuário não é consultor ou feature `multi_org_dashboard` ausente
+
+---
+
+### GET `/v1/consultant/expenses-by-category`
+
+Despesas agrupadas por categoria de todas as organizações do consultor.
+
+**Request:**
+```typescript
+interface ExpensesByCategoryQuery {
+  date_start?: string;  // YYYY-MM-DD (opcional)
+  date_end?: string;    // YYYY-MM-DD (opcional)
+}
+
+interface CategoryExpenseItem {
+  name: string;       // Nome da categoria
+  total: number;      // Total gasto
+  percentage: number; // % do total
+}
+
+interface ExpensesByCategoryResponse {
+  categories: CategoryExpenseItem[];
+  total_expenses: number;
+  period_start: string;  // YYYY-MM-DD
+  period_end: string;    // YYYY-MM-DD
+}
+
+const getExpensesByCategory = async (
+  params?: ExpensesByCategoryQuery
+): Promise<ExpensesByCategoryResponse> => {
+  const response = await apiClient.get<ExpensesByCategoryResponse>(
+    '/v1/consultant/expenses-by-category',
+    { params }
+  );
+  return response.data;
+};
+```
+
+**Exemplo:**
+```typescript
+const expenses = await getExpensesByCategory({
+  date_start: '2025-01-01',
+  date_end: '2025-01-31'
+});
+expenses.categories.forEach((cat) => {
+  console.log(`${cat.name}: R$ ${cat.total} (${cat.percentage}%)`);
+});
+```
+
+**Response (200):**
+```typescript
+{
+  categories: [
+    { name: "alimentação", total: 8500.00, percentage: 26.56 },
+    { name: "transporte", total: 6200.00, percentage: 19.38 },
+    { name: "moradia", total: 12000.00, percentage: 37.50 },
+    { name: "lazer", total: 5300.00, percentage: 16.56 }
+  ],
+  total_expenses: 32000.00,
+  period_start: "2025-01-01",
+  period_end: "2025-01-31"
+}
+```
+
+**Erros:**
+- `401`: Não autenticado
+- `403`: Usuário não é consultor ou feature `multi_org_dashboard` ausente
+
+---
+
+### GET `/v1/consultant/income-commitment`
+
+Comprometimento de renda (faturas de cartão vs receita) de todas as organizações do consultor.
+
+**Request:**
+```typescript
+interface IncomeCommitmentQuery {
+  date_start?: string;  // YYYY-MM-DD (opcional)
+  date_end?: string;    // YYYY-MM-DD (opcional)
+}
+
+interface MonthlyIncomeCommitmentItem {
+  month: string;
+  year: number;
+  month_number: number;
+  income_commitment_percent: number;  // % da renda comprometida com cartões
+  total_income: number;
+  total_card_bills: number;
+}
+
+interface IncomeCommitmentResponse {
+  monthly_data: MonthlyIncomeCommitmentItem[];
+  period_start: string;  // YYYY-MM-DD
+  period_end: string;    // YYYY-MM-DD
+}
+
+const getIncomeCommitment = async (
+  params?: IncomeCommitmentQuery
+): Promise<IncomeCommitmentResponse> => {
+  const response = await apiClient.get<IncomeCommitmentResponse>(
+    '/v1/consultant/income-commitment',
+    { params }
+  );
+  return response.data;
+};
+```
+
+**Exemplo:**
+```typescript
+const commitment = await getIncomeCommitment({
+  date_start: '2025-01-01',
+  date_end: '2025-03-31'
+});
+commitment.monthly_data.forEach((month) => {
+  console.log(`${month.month}: ${month.income_commitment_percent}% comprometido`);
+});
+```
+
+**Response (200):**
+```typescript
+{
+  monthly_data: [
+    {
+      month: "2025-01",
+      year: 2025,
+      month_number: 1,
+      income_commitment_percent: 35.5,
+      total_income: 50000.00,
+      total_card_bills: 17750.00
+    }
+  ],
+  period_start: "2025-01-01",
+  period_end: "2025-03-31"
+}
+```
+
+**Erros:**
+- `401`: Não autenticado
+- `403`: Usuário não é consultor ou feature `multi_org_dashboard` ausente
+
+---
+
+### GET `/v1/consultant/goals-progress-by-type`
+
+Progresso das metas agrupadas por tipo de todas as organizações do consultor.
+
+**Request:**
+```typescript
+interface GoalsProgressByTypeQuery {
+  as_of_date?: string;  // YYYY-MM-DD (opcional, padrão: hoje)
+}
+
+interface GoalProgressByTypeItem {
+  goal_name: string;     // Nome/tipo da meta
+  avg_progress: number;  // Progresso médio (0-100%)
+  count: number;         // Quantidade de metas deste tipo
+}
+
+interface GoalsProgressByTypeResponse {
+  by_type: GoalProgressByTypeItem[];
+  organizations_count: number;
+  as_of_date: string;  // YYYY-MM-DD
+}
+
+const getGoalsProgressByType = async (
+  params?: GoalsProgressByTypeQuery
+): Promise<GoalsProgressByTypeResponse> => {
+  const response = await apiClient.get<GoalsProgressByTypeResponse>(
+    '/v1/consultant/goals-progress-by-type',
+    { params }
+  );
+  return response.data;
+};
+```
+
+**Exemplo:**
+```typescript
+const progress = await getGoalsProgressByType();
+progress.by_type.forEach((type) => {
+  console.log(`${type.goal_name}: ${type.avg_progress}% médio (${type.count} metas)`);
+});
+```
+
+**Response (200):**
+```typescript
+{
+  by_type: [
+    { goal_name: "reserva_emergencia", avg_progress: 65.5, count: 5 },
+    { goal_name: "viagem", avg_progress: 42.0, count: 3 },
+    { goal_name: "carro", avg_progress: 28.5, count: 2 }
+  ],
+  organizations_count: 8,
+  as_of_date: "2025-01-31"
+}
+```
+
+**Erros:**
+- `401`: Não autenticado
+- `403`: Usuário não é consultor ou feature `multi_org_dashboard` ausente
+
+---
+
+### GET `/v1/consultant/clients-at-risk`
+
+Lista de clientes em risco (gastos > receita ou alto endividamento) do consultor.
+
+**Request:**
+```typescript
+interface ClientsAtRiskQuery {
+  as_of_date?: string;              // YYYY-MM-DD (opcional, padrão: hoje)
+  limit?: number;                   // Máximo de clientes (1-100, padrão: 10)
+  gasto_maior_renda_meses?: number; // Meses com gasto > receita para flag (1-12, padrão: 3)
+  endividamento_max_percent?: number; // % máximo dívida/renda para flag (0-100, padrão: 70)
+  exigir_reserva_emergencia?: boolean; // Exigir reserva de emergência (padrão: false)
+}
+
+interface ClientAtRiskItem {
+  organization_id: string;
+  organization_name: string;
+  main_situation: string;     // Motivo principal do risco
+  current_balance: number;
+  last_invoice_status: string;
+  risk_score: number;         // 1-100 (maior = mais risco)
+}
+
+interface ClientsAtRiskResponse {
+  clients: ClientAtRiskItem[];
+  total: number;
+  as_of_date: string;  // YYYY-MM-DD
+}
+
+const getClientsAtRisk = async (
+  params?: ClientsAtRiskQuery
+): Promise<ClientsAtRiskResponse> => {
+  const response = await apiClient.get<ClientsAtRiskResponse>(
+    '/v1/consultant/clients-at-risk',
+    { params }
+  );
+  return response.data;
+};
+```
+
+**Exemplo:**
+```typescript
+const atRisk = await getClientsAtRisk({
+  limit: 5,
+  gasto_maior_renda_meses: 3,
+  endividamento_max_percent: 70
+});
+console.log(`${atRisk.total} clientes em risco:`);
+atRisk.clients.forEach((client) => {
+  console.log(`${client.organization_name}: ${client.main_situation} (score: ${client.risk_score})`);
+});
+```
+
+**Response (200):**
+```typescript
+{
+  clients: [
+    {
+      organization_id: "123e4567-e89b-12d3-a456-426614174000",
+      organization_name: "Empresa ABC",
+      main_situation: "Gastos maiores que receita por 3 meses",
+      current_balance: -2500.00,
+      last_invoice_status: "unpaid",
+      risk_score: 85
+    },
+    {
+      organization_id: "223e4567-e89b-12d3-a456-426614174001",
+      organization_name: "Empresa XYZ",
+      main_situation: "Endividamento acima de 70% da receita",
+      current_balance: 500.00,
+      last_invoice_status: "paid",
+      risk_score: 72
+    }
+  ],
+  total: 2,
+  as_of_date: "2025-01-31"
+}
+```
+
+**Erros:**
+- `401`: Não autenticado
+- `403`: Usuário não é consultor ou feature `multi_org_dashboard` ausente
+
+---
+
 ## 📊 Endpoints de Simulação Financeira
 
 ### POST `/v1/financial-impact/simulate`
@@ -4237,5 +5029,5 @@ interface EndingInstallmentAllCards {
 
 ---
 
-**Última atualização**: Janeiro 2026 (v1 API)
+**Última atualização**: Fevereiro 2026 (v1 API)
 

--- a/docs/FRONTEND_TRANSACTIONS_INSTALLMENTS_DISPLAY.md
+++ b/docs/FRONTEND_TRANSACTIONS_INSTALLMENTS_DISPLAY.md
@@ -1,0 +1,296 @@
+# Exibição de Transações com Parcelas no Frontend
+
+> **Objetivo:** Este documento descreve como o frontend deve exibir transações de cartão de crédito parcelado na tela de listagem, utilizando o campo `installment_info` retornado pela API.
+
+---
+
+## 1. Contexto
+
+O endpoint `GET /v1/transactions` passou a incluir transações de cartão de crédito com base no **vencimento das parcelas** (e não na data da compra) quando filtros de data (`date_start` e `date_end`) são informados.
+
+Quando uma transação aparece na lista por causa de parcelas que vencem no período, a API retorna a **transação original** com um array opcional `installment_info`, contendo as parcelas cujo vencimento está no range.
+
+---
+
+## 2. Estrutura da API
+
+### 2.1. Resposta do endpoint
+
+```typescript
+interface Transaction {
+  id: number;
+  organization_id: string;
+  type: 'income' | 'expense';
+  description: string;
+  tags: Record<string, Tag[]>;
+  value: number;                    // Valor total da transação
+  payment_method: string;           // Ex: "pix", "credit_card", "debit_card"
+  date: string;                    // Data da compra (ISO datetime)
+  recurring: boolean;
+  created_at: string;
+  updated_at: string;
+  credit_card_charge?: CreditCardChargeInfo | null;
+  installment_info?: InstallmentInfo[] | null;  // ← NOVO: parcelas no range
+  category?: string | null;
+}
+
+interface InstallmentInfo {
+  installment_number: number;   // Ex: 1, 2, 3
+  total_installments: number;   // Ex: 6
+  due_date: string;            // YYYY-MM-DD (data de vencimento)
+  amount: number;               // Valor da parcela
+}
+```
+
+### 2.2. Quando `installment_info` está presente
+
+- `installment_info` só existe quando a transação foi incluída na lista **por causa de parcelas** cujo vencimento está no período filtrado.
+- O array contém **todas as parcelas** dessa transação que vencem no range.
+- Pode haver 1 ou mais parcelas no array (ex.: compra em 6x com 2 parcelas vencendo em fevereiro).
+
+### 2.3. Exemplo de resposta
+
+```json
+{
+  "id": 351,
+  "description": "Geladeira - Magazine Luiza",
+  "value": 600.00,
+  "payment_method": "credit_card",
+  "date": "2026-01-05T10:00:00",
+  "credit_card_charge": { "charge": {...}, "card": {...} },
+  "installment_info": [
+    { "installment_number": 1, "total_installments": 6, "due_date": "2026-02-05", "amount": 100.00 },
+    { "installment_number": 2, "total_installments": 6, "due_date": "2026-02-12", "amount": 100.00 }
+  ]
+}
+```
+
+---
+
+## 3. Regras de Exibição na Tabela
+
+### 3.1. Transação sem `installment_info`
+
+Exibir **uma linha** usando os dados da própria transação:
+
+| Campo | Fonte |
+|-------|-------|
+| Descrição | `transaction.description` |
+| Categoria | `transaction.tags.categoria[0].name` ou `transaction.category` |
+| Data | `transaction.date` (formatado) |
+| Forma de Pagamento | Mapear `transaction.payment_method` (PIX, Cartão de Débito, Cartão à vista, etc.) |
+| Valor | `transaction.value` |
+| Ações | Editar/Excluir usando `transaction.id` |
+
+### 3.2. Transação com `installment_info`
+
+Exibir **uma linha por parcela**, em sequência, ordenadas por `due_date`:
+
+| Campo | Fonte |
+|-------|-------|
+| Descrição | `transaction.description` (mesma em todas as linhas) |
+| Categoria | `transaction.tags.categoria[0].name` ou `transaction.category` |
+| Data | `installment.due_date` (formatado) |
+| Forma de Pagamento | `Cartão parcelado (X/Y)` onde X = `installment_number`, Y = `total_installments` |
+| Valor | `installment.amount` |
+| Ações | Editar/Excluir usando `transaction.id` (sempre a transação original) |
+
+**Importante:** As linhas devem ficar **consecutivas** (uma logo após a outra), agrupadas pela mesma transação.
+
+---
+
+## 4. Mockup da Tabela
+
+### 4.1. Exemplo completo
+
+```
+┌─────────────────────┬──────────────────┬──────────────┬─────────────────────────┬────────────┬────────┐
+│ Descrição           │ Categoria        │ Data         │ Forma de Pagamento      │ Valor      │ Ações  │
+├─────────────────────┼──────────────────┼──────────────┼─────────────────────────┼────────────┼────────┤
+│ Contas e Trans...   │ Transporte       │ 16/02/2026   │ PIX                     │ -R$ 571,50 │ ✏️ 🗑️  │
+│ Padaria             │ Alimentação      │ 13/02/2026   │ Cartão à vista          │ -R$ 35,00  │ ✏️ 🗑️  │
+│ Supermercado Assaí  │ Alimentação      │ 10/02/2026   │ Cartão parcelado (1/3)  │ -R$ 100,00 │ ✏️ 🗑️  │
+│ Geladeira           │ Casa & Decoração │ 05/02/2026   │ Cartão parcelado (1/6) │ -R$ 100,00 │ ✏️ 🗑️  │
+│ Geladeira           │ Casa & Decoração │ 12/02/2026   │ Cartão parcelado (2/6)  │ -R$ 100,00 │ ✏️ 🗑️  │
+│ Salário February    │ Salário & Pró-.. │ 06/02/2026   │ PIX                     │ +R$ 7.500  │ ✏️ 🗑️  │
+└─────────────────────┴──────────────────┴──────────────┴─────────────────────────┴────────────┴────────┘
+```
+
+### 4.2. Casos de uso
+
+| Cenário | Linhas exibidas |
+|---------|-----------------|
+| Transação PIX | 1 linha |
+| Transação cartão à vista | 1 linha |
+| Transação parcelada, 1 parcela no período | 1 linha |
+| Transação parcelada, 2 parcelas no período | 2 linhas consecutivas |
+| Transação parcelada, N parcelas no período | N linhas consecutivas |
+
+---
+
+## 5. Implementação Sugerida
+
+### 5.1. Função para expandir transações em linhas da tabela
+
+```typescript
+interface TableRow {
+  transactionId: number;
+  description: string;
+  category: string;
+  displayDate: string;
+  displayPaymentMethod: string;
+  displayValue: number;
+  type: 'income' | 'expense';
+  // ... outros campos necessários para a linha
+}
+
+function expandTransactionsToRows(transactions: Transaction[]): TableRow[] {
+  const rows: TableRow[] = [];
+
+  for (const tx of transactions) {
+    if (tx.installment_info?.length) {
+      // Ordenar parcelas por due_date
+      const sorted = [...tx.installment_info].sort(
+        (a, b) => a.due_date.localeCompare(b.due_date)
+      );
+
+      for (const inst of sorted) {
+        rows.push({
+          transactionId: tx.id,
+          description: tx.description,
+          category: tx.category ?? tx.tags?.categoria?.[0]?.name ?? '-',
+          displayDate: formatDate(inst.due_date),  // Ex: "10/02/2026"
+          displayPaymentMethod: `Cartão parcelado (${inst.installment_number}/${inst.total_installments})`,
+          displayValue: inst.amount,
+          type: tx.type,
+          // ... copiar outros campos necessários
+        });
+      }
+    } else {
+      rows.push({
+        transactionId: tx.id,
+        description: tx.description,
+        category: tx.category ?? tx.tags?.categoria?.[0]?.name ?? '-',
+        displayDate: formatDate(tx.date),
+        displayPaymentMethod: mapPaymentMethod(tx.payment_method),
+        displayValue: tx.value,
+        type: tx.type,
+        // ...
+      });
+    }
+  }
+
+  return rows;
+}
+```
+
+### 5.2. Mapeamento de `payment_method`
+
+Para transações **sem** `installment_info`, mapear o valor da API para o label exibido:
+
+```typescript
+function mapPaymentMethod(method: string): string {
+  const map: Record<string, string> = {
+    pix: 'PIX',
+    debit_card: 'Cartão de Débito',
+    credit_card: 'Cartão à vista',  // Quando não tem installment_info
+    bank_transfer: 'Transferência',
+    // ... outros
+  };
+  return map[method] ?? method;
+}
+```
+
+### 5.3. Tooltip / Hover — Informações detalhadas da parcela
+
+Ao passar o mouse sobre a célula **Forma de Pagamento** (ex.: "Cartão parcelado (1/3)"), exibir um tooltip com:
+
+| Campo | Fonte |
+|-------|-------|
+| Data da compra | `transaction.date` (formatado) |
+| Parcela | `installment_number` de `total_installments` |
+| Vencimento | `installment.due_date` (formatado) |
+| Valor da parcela | `installment.amount` |
+| Valor total da compra | `transaction.value` |
+
+**Exemplo visual do tooltip:**
+
+```
+┌─────────────────────────────┐
+│ Compra: 10/01/2026           │
+│ Parcela 1 de 3               │
+│ Vencimento: 10/02/2026       │
+│ Valor da parcela: R$ 100,00  │
+│ Valor total: R$ 300,00       │
+└─────────────────────────────┘
+```
+
+**Implementação sugerida:**
+
+```typescript
+// Componente de tooltip para linha com installment_info
+function InstallmentTooltip({ tx, inst }: { tx: Transaction; inst: InstallmentInfo }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger>Cartão parcelado ({inst.installment_number}/{inst.total_installments})</TooltipTrigger>
+      <TooltipContent>
+        <p>Compra: {formatDate(tx.date)}</p>
+        <p>Parcela {inst.installment_number} de {inst.total_installments}</p>
+        <p>Vencimento: {formatDate(inst.due_date)}</p>
+        <p>Valor da parcela: {formatCurrency(inst.amount)}</p>
+        <p>Valor total: {formatCurrency(tx.value)}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+```
+
+### 5.4. Ações (Editar / Excluir)
+
+Sempre usar `transactionId` (ou `transaction.id`) para as ações:
+
+- **Editar:** navegar para `/transactions/{transactionId}/edit`
+- **Excluir:** chamar API `DELETE /v1/transactions/{transactionId}`
+
+Isso vale tanto para linhas normais quanto para linhas de parcelas — a edição/exclusão é sempre da transação original.
+
+---
+
+## 6. Ordenação
+
+A API já retorna as transações ordenadas por data efetiva (compra ou vencimento). O frontend deve:
+
+1. Manter a ordem recebida da API.
+2. Ao expandir transações com `installment_info`, garantir que as linhas de parcelas fiquem consecutivas e ordenadas por `due_date` entre si.
+
+---
+
+## 7. Paginação e Total
+
+- O `total` retornado na paginação refere-se ao **número de transações** (não ao número de linhas expandidas).
+- Se uma transação com 2 parcelas no período estiver na página atual, a tabela terá 2 linhas a mais que o `limit` de transações.
+- O frontend não precisa alterar a lógica de paginação; apenas expande as transações da página atual em linhas.
+
+---
+
+## 8. Resumo dos Pontos Críticos
+
+| Item | Regra |
+|------|-------|
+| **Quando expandir** | Sempre que `installment_info` existir e tiver length > 0 |
+| **Linhas por parcela** | Uma linha por item em `installment_info` |
+| **Ordem das parcelas** | Por `due_date` ascendente |
+| **Agrupamento** | Linhas da mesma transação devem ficar consecutivas |
+| **ID para ações** | Sempre `transaction.id` |
+| **Valor exibido** | `installment.amount` (não `transaction.value`) |
+| **Data exibida** | `installment.due_date` (não `transaction.date`) |
+| **Label da parcela** | `Cartão parcelado (X/Y)` |
+| **Tooltip no hover** | Exibir: data da compra, parcela X/Y, vencimento, valor da parcela, valor total |
+
+---
+
+## 9. Referências
+
+- **API:** `docs/FRONTEND_API_GUIDE.md` — seção `GET /v1/transactions`
+- **Tipos TypeScript:** `Transaction`, `InstallmentInfo` já documentados no guia
+- **Exemplo de resposta:** Ver seção 2.3 deste documento

--- a/docs/plans/2025-02-22-consultant-area-design.md
+++ b/docs/plans/2025-02-22-consultant-area-design.md
@@ -1,0 +1,86 @@
+# Design: Área do Consultor
+
+**Data:** 2025-02-22  
+**Status:** Aprovado
+
+---
+
+## Resumo
+
+Implementar a área do consultor no frontend Fincla: dashboard consolidado com resumo de todas as organizações do consultor, lista de clientes, e visão dedicada por cliente com URLs compartilháveis e reuso total dos componentes existentes.
+
+---
+
+## Decisões de produto
+
+1. **Acesso:** Quando o usuário é consultor, o Dashboard (`/`) redireciona para `/consultant`.
+2. **Layout:** Visão consolidada em destaque (cards de resumo), lista de clientes em segundo plano.
+3. **Clique no cliente:** Navega para página dedicada `/consultant/clients/:organizationId` com visão completa e análises.
+4. **Resumo por cliente:** Usar `GET /v1/transactions/summary?organization_id=X` (endpoint existente).
+5. **URLs compartilháveis:** Rotas explícitas para compartilhamento e contexto claro.
+
+---
+
+## Arquitetura e rotas
+
+### Rotas
+
+| Rota | Quem | Comportamento |
+|------|------|---------------|
+| `/` | Não consultor | Dashboard normal (atual) |
+| `/` | Consultor | Redireciona para `/consultant` |
+| `/consultant` | Consultor | Dashboard consolidado |
+| `/consultant/clients/:organizationId` | Consultor | Visão do cliente (Dashboard) |
+| `/consultant/clients/:organizationId/transactions` | Consultor | Transações do cliente |
+| `/consultant/clients/:organizationId/reports` | Consultor | Relatórios do cliente |
+| `/consultant/clients/:organizationId/credit-cards` | Consultor | Cartões do cliente |
+| `/consultant/clients/:organizationId/goals` | Consultor | Metas do cliente |
+
+### Detecção de consultor
+
+`isConsultant(user)`: retorna `true` se `user?.subscription?.features` inclui pelo menos uma de: `multi_org_dashboard`, `client_list`, `consolidated_reports`.
+
+### useOrganization e URL
+
+- Em rotas `/consultant/clients/:organizationId` (e subrotas), o `organizationId` da URL tem prioridade sobre localStorage.
+- `useOrganization` usa `useRoute` para detectar e retornar `params.organizationId` como `activeOrgId` efetivo.
+- Ao sair da rota de cliente, volta ao valor do localStorage.
+
+---
+
+## Layout e componentes
+
+### Dashboard consolidado (`/consultant`)
+
+- Mesmo `AppLayout`, título "Consultor".
+- Seletor de org no header: oculto ou "Visão consolidada".
+- Blocos: DateRangePicker → ConsultantSummaryCards → ConsultantClientList.
+- Botão "Ver detalhes" na lista → navega para `/consultant/clients/:organizationId`.
+
+### Visão do cliente (`/consultant/clients/:organizationId`)
+
+- `AppLayout` com breadcrumb: **Consultor** > **[Nome do cliente]** > [Página].
+- Seletor de org mostra cliente atual; permite trocar para outro cliente.
+- Conteúdo: reuso de Dashboard, Transações, Relatórios, Cartões, Metas.
+
+### Sidebar
+
+- Item "Consultor" (ícone `Users` ou `Briefcase`) → `/consultant`.
+- Visível apenas se `isConsultant(user)`.
+
+---
+
+## API
+
+- `GET /v1/consultant/summary` — resumo consolidado (multi_org_dashboard).
+- `GET /v1/consultant/clients` — lista de clientes (client_list).
+- `GET /v1/consultant/reports/consolidated` — relatório consolidado (consolidated_reports).
+- `GET /v1/transactions/summary?organization_id=X` — resumo por cliente (existente).
+
+---
+
+## Tratamento de erros
+
+- 403 em endpoints de consultor: usuário não é consultor ou feature ausente → toast e/ou redirecionar para `/`.
+- 401: fluxo padrão (logout).
+- Loading e estados vazios: skeletons e mensagens adequadas.

--- a/docs/plans/2025-02-22-consultant-area.md
+++ b/docs/plans/2025-02-22-consultant-area.md
@@ -1,0 +1,474 @@
+# Área do Consultor — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implementar a área do consultor com dashboard consolidado, lista de clientes e visão dedicada por cliente com URLs compartilháveis.
+
+**Architecture:** Rotas explícitas (`/consultant`, `/consultant/clients/:organizationId`). `useOrganization` prioriza `organizationId` da URL quando em rota de cliente. Reuso total de Dashboard, Transações, Relatórios, etc. Consultor detectado via `user.subscription.features`.
+
+**Tech Stack:** React, TypeScript, wouter, TanStack Query, axios. Ver `docs/FRONTEND_API_GUIDE.md` (seção "Endpoints da Área do Consultor").
+
+**Design doc:** `docs/plans/2025-02-22-consultant-area-design.md`
+
+---
+
+## Task 1: Tipos e API do consultor
+
+**Files:**
+- Modify: `src/types/api.ts`
+- Create: `src/api/consultant.ts`
+
+**Step 1: Adicionar tipos em `src/types/api.ts`**
+
+Adicionar após os tipos de Goals (ou em seção apropriada):
+
+```typescript
+// ===== CONSULTANT =====
+export interface ConsultantSummaryQuery {
+  date_start?: string;
+  date_end?: string;
+}
+
+export interface ConsultantSummaryResponse {
+  total_income: number;
+  total_expenses: number;
+  balance: number;
+  total_transactions: number;
+  organizations_count: number;
+  period_start: string | null;
+  period_end: string | null;
+}
+
+export interface ConsultantClient {
+  organization_id: string;
+  organization_name: string;
+  role: 'owner' | 'member';
+  membership_created_at: string;
+}
+
+export interface ConsultantClientsResponse {
+  total: number;
+  clients: ConsultantClient[];
+}
+```
+
+**Step 2: Criar `src/api/consultant.ts`**
+
+```typescript
+import apiClient from './client';
+import type {
+  ConsultantSummaryQuery,
+  ConsultantSummaryResponse,
+  ConsultantClientsResponse,
+} from '../types/api';
+
+export const getConsultantSummary = async (
+  params?: ConsultantSummaryQuery
+): Promise<ConsultantSummaryResponse> => {
+  const response = await apiClient.get<ConsultantSummaryResponse>(
+    '/consultant/summary',
+    { params }
+  );
+  return response.data;
+};
+
+export const getConsultantClients = async (): Promise<ConsultantClientsResponse> => {
+  const response = await apiClient.get<ConsultantClientsResponse>(
+    '/consultant/clients'
+  );
+  return response.data;
+};
+
+export const getConsultantConsolidatedReport = async (
+  params?: ConsultantSummaryQuery
+): Promise<ConsultantSummaryResponse> => {
+  const response = await apiClient.get<ConsultantSummaryResponse>(
+    '/consultant/reports/consolidated',
+    { params }
+  );
+  return response.data;
+};
+```
+
+**Step 3: Verificar compilação**
+
+Run: `npm run check`  
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add src/types/api.ts src/api/consultant.ts
+git commit -m "feat(consultant): add API types and client"
+```
+
+---
+
+## Task 2: Utilitário isConsultant
+
+**Files:**
+- Create: `src/lib/consultant.ts`
+
+**Step 1: Criar `src/lib/consultant.ts`**
+
+```typescript
+import type { User } from '@/types/api';
+
+const CONSULTANT_FEATURES = [
+  'multi_org_dashboard',
+  'client_list',
+  'consolidated_reports',
+] as const;
+
+export function isConsultant(user: User | null | undefined): boolean {
+  if (!user?.subscription?.features?.length) return false;
+  return CONSULTANT_FEATURES.some((f) =>
+    user.subscription!.features!.includes(f)
+  );
+}
+```
+
+**Step 2: Escrever teste**
+
+Create: `src/lib/__tests__/consultant.test.ts`
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { isConsultant } from '../consultant';
+import type { User } from '@/types/api';
+
+describe('isConsultant', () => {
+  it('returns false when user is null', () => {
+    expect(isConsultant(null)).toBe(false);
+  });
+
+  it('returns false when user has no subscription', () => {
+    expect(isConsultant({ id: '1', email: 'a@b.com', role: 'owner', created_at: '' } as User)).toBe(false);
+  });
+
+  it('returns true when user has multi_org_dashboard', () => {
+    const user: User = {
+      id: '1',
+      email: 'a@b.com',
+      role: 'owner',
+      created_at: '',
+      subscription: { plan: 'premium', status: 'active', max_organizations: 10, max_users_per_org: 5, features: ['multi_org_dashboard'] },
+    };
+    expect(isConsultant(user)).toBe(true);
+  });
+
+  it('returns false when user has no consultant features', () => {
+    const user: User = {
+      id: '1',
+      email: 'a@b.com',
+      role: 'owner',
+      created_at: '',
+      subscription: { plan: 'free', status: 'active', max_organizations: 1, max_users_per_org: 1, features: [] },
+    };
+    expect(isConsultant(user)).toBe(false);
+  });
+});
+```
+
+**Step 3: Rodar teste**
+
+Run: `npm run test -- src/lib/__tests__/consultant.test.ts`  
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add src/lib/consultant.ts src/lib/__tests__/consultant.test.ts
+git commit -m "feat(consultant): add isConsultant utility"
+```
+
+---
+
+## Task 3: useOrganization com suporte a URL
+
+**Files:**
+- Modify: `src/hooks/useOrganization.ts`
+
+**Step 1: Adicionar lógica de URL**
+
+- Importar `useRoute` e `useLocation` de `wouter`.
+- No início do hook, chamar `const [match, params] = useRoute('/consultant/clients/:organizationId*');` (wouter usa `*` para subrotas) — ou usar `useLocation` e regex/parse para extrair orgId.
+- Alternativa mais simples: `useRoute` com padrão exato `/consultant/clients/:organizationId` e, para subrotas, usar outro `useRoute` ou `useLocation` + parse.
+
+Verificar documentação wouter: `useRoute('/consultant/clients/:organizationId')` retorna `[match, params]`. Para subrotas como `/consultant/clients/xyz/transactions`, o padrão `/consultant/clients/:organizationId` pode não dar match. Usar `useRoute('/consultant/clients/:organizationId/:rest*')` ou `useLocation()` e extrair o segundo segmento.
+
+Solução: `const [location] = useLocation();` e `const match = /^\/consultant\/clients\/([^/]+)/.exec(location); const urlOrgId = match?.[1] ?? null;`
+
+**Implementação em `useOrganization.ts`:**
+
+```typescript
+import { useLocation } from 'wouter';
+
+// No início do hook, após os imports:
+const [location] = useLocation();
+const urlOrgIdMatch = /^\/consultant\/clients\/([^/]+)/.exec(location);
+const urlOrgId = urlOrgIdMatch?.[1] ?? null;
+
+// O activeOrgId efetivo: URL tem prioridade
+const effectiveOrgId = urlOrgId ?? activeOrgId;
+```
+
+- Trocar todas as referências a `activeOrgId` no retorno e em `activeOrganization` por `effectiveOrgId` quando for o valor "efetivo" usado pelas páginas.
+- Manter `activeOrgId` e `setActiveOrgId` para o estado persistido (localStorage); `effectiveOrgId` é o que as páginas consomem.
+- `selectOrganization` ao ser chamado: se estamos em rota de cliente, navegar para `/consultant/clients/${organizationId}` em vez de só setar state (para atualizar a URL).
+
+**Step 2: Atualizar retorno**
+
+Retornar `activeOrgId: effectiveOrgId` (ou `effectiveOrgId` como `activeOrgId` para não quebrar consumidores). Os consumidores usam `activeOrgId` para requests — então o valor retornado deve ser `effectiveOrgId`. Manter o nome `activeOrgId` para compatibilidade.
+
+**Step 3: Garantir que selectOrganization em rota de cliente navegue**
+
+Quando `urlOrgId` existe e chamamos `selectOrganization(newId)`, fazer `setLocation(`/consultant/clients/${newId}`)` para atualizar a URL. Caso contrário, apenas `setActiveOrgId` + localStorage.
+
+**Step 4: Rodar testes existentes**
+
+Run: `npm run test -- src/hooks/`  
+Expected: testes passam (pode ser necessário ajustar mocks se useOrganization for testado).
+
+**Step 5: Commit**
+
+```bash
+git add src/hooks/useOrganization.ts
+git commit -m "feat(consultant): useOrganization prioritizes orgId from URL"
+```
+
+---
+
+## Task 4: Hook useConsultantData
+
+**Files:**
+- Create: `src/hooks/useConsultantData.ts`
+
+**Step 1: Criar hook**
+
+```typescript
+import { useQuery } from '@tanstack/react-query';
+import { getConsultantSummary, getConsultantClients } from '@/api/consultant';
+import type { ConsultantSummaryQuery } from '@/types/api';
+
+export function useConsultantSummary(params?: ConsultantSummaryQuery) {
+  return useQuery({
+    queryKey: ['consultant-summary', params?.date_start, params?.date_end],
+    queryFn: () => getConsultantSummary(params),
+  });
+}
+
+export function useConsultantClients() {
+  return useQuery({
+    queryKey: ['consultant-clients'],
+    queryFn: getConsultantClients,
+  });
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/hooks/useConsultantData.ts
+git commit -m "feat(consultant): add useConsultantSummary and useConsultantClients"
+```
+
+---
+
+## Task 5: Página ConsultantDashboard
+
+**Files:**
+- Create: `src/pages/consultant/index.tsx`
+- Create: `src/components/consultant/ConsultantSummaryCards.tsx`
+- Create: `src/components/consultant/ConsultantClientList.tsx`
+
+**Step 1: Criar ConsultantSummaryCards**
+
+Componente que recebe `ConsultantSummaryResponse` e exibe cards (Receitas, Despesas, Balanço, Transações, Clientes). Reutilizar estilos do `SummaryCards` existente.
+
+**Step 2: Criar ConsultantClientList**
+
+Tabela ou lista de clientes com: nome, role, data de vínculo, botão "Ver detalhes" que navega para `/consultant/clients/${client.organization_id}`.
+
+**Step 3: Criar ConsultantDashboard**
+
+Página com DateRangePicker, ConsultantSummaryCards, ConsultantClientList. Usar `useConsultantSummary` e `useConsultantClients`. Tratar loading e erro (403 → toast + mensagem).
+
+**Step 4: Verificar compilação**
+
+Run: `npm run check`  
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/pages/consultant/index.tsx src/components/consultant/
+git commit -m "feat(consultant): add ConsultantDashboard page and components"
+```
+
+---
+
+## Task 6: ConsultantClientLayout e rotas
+
+**Files:**
+- Create: `src/layouts/ConsultantClientLayout.tsx`
+- Modify: `src/App.tsx`
+- Modify: `src/layouts/AppLayout.tsx`
+
+**Step 1: Criar ConsultantClientLayout**
+
+Layout que:
+- Lê `organizationId` da URL (via `useRoute` ou `useLocation` + parse).
+- Garante que `useOrganization` já retorna esse ID (Task 3).
+- Renderiza `AppLayout` com children.
+- Adiciona breadcrumb: Consultor > [Nome do cliente] (nome vindo de `organizations.find(o => o.id === orgId)`).
+
+**Step 2: Adicionar rotas no App.tsx**
+
+- Rota `/` deve redirecionar para `/consultant` se consultor (componente wrapper ou Redirect).
+- Adicionar `<Route path="/consultant" component={ConsultantDashboard} />`.
+- Adicionar rotas aninhadas para `/consultant/clients/:organizationId` com ConsultantClientLayout, renderizando Dashboard, Transactions, Reports, etc.
+
+Estrutura sugerida:
+
+```tsx
+<Route path="/">
+  <DashboardOrRedirect />
+</Route>
+<Route path="/consultant" component={ConsultantDashboard} />
+<Route path="/consultant/clients/:organizationId">
+  <ConsultantClientLayout>
+    <Switch>
+      <Route path="/consultant/clients/:organizationId" component={Dashboard} />
+      <Route path="/consultant/clients/:organizationId/transactions" component={TransactionsPage} />
+      ...
+    </Switch>
+  </ConsultantClientLayout>
+</Route>
+```
+
+Nota: wouter pode precisar de estrutura diferente para rotas aninhadas. Verificar se `Route path="/consultant/clients/:organizationId"` com `component` que renderiza children funciona.
+
+**Step 3: Atualizar AppLayout**
+
+- Adicionar item "Consultor" na sidebar quando `isConsultant(user)`.
+- Adicionar `ROUTE_TITLES` para `/consultant` e `/consultant/clients/:organizationId`.
+- Em rotas de cliente, o seletor de org deve listar os clientes e navegar para `/consultant/clients/:id` ao trocar.
+
+**Step 4: Criar DashboardOrRedirect**
+
+Componente que usa `useAuth` e `isConsultant`; se consultor, `<Redirect to="/consultant" />`, senão `<Dashboard />`.
+
+**Step 5: Verificar fluxo**
+
+Run: `npm run dev`, navegar manualmente para `/consultant` e `/consultant/clients/:id`.  
+Expected: páginas carregam sem erro.
+
+**Step 6: Commit**
+
+```bash
+git add src/App.tsx src/layouts/AppLayout.tsx src/layouts/ConsultantClientLayout.tsx
+git commit -m "feat(consultant): add routes and ConsultantClientLayout"
+```
+
+---
+
+## Task 7: Breadcrumb e navegação
+
+**Files:**
+- Modify: `src/components/Breadcrumb.tsx` (ou criar ConsultantBreadcrumb)
+- Modify: `src/layouts/AppLayout.tsx`
+
+**Step 1: Breadcrumb para consultor**
+
+Quando em `/consultant`: "Consultor".  
+Quando em `/consultant/clients/:id`: "Consultor > [Nome do cliente] > [Página]".
+
+**Step 2: Links na sidebar para cliente**
+
+Os links de Transações, Relatórios, etc. devem apontar para `/consultant/clients/:organizationId/transactions` quando em rota de cliente, em vez de `/transactions`.
+
+**Step 3: Ajustar AppLayout**
+
+AppLayout precisa saber se está em "modo consultor cliente" (via `useLocation` ou prop) para gerar os links corretos.
+
+**Step 4: Commit**
+
+```bash
+git add src/components/Breadcrumb.tsx src/layouts/AppLayout.tsx
+git commit -m "feat(consultant): breadcrumb and sidebar links for client view"
+```
+
+---
+
+## Task 8: Tratamento de erros e estados
+
+**Files:**
+- Modify: `src/pages/consultant/index.tsx`
+- Modify: `src/hooks/useConsultantData.ts` (opcional: retry false em 403)
+
+**Step 1: Tratar 403**
+
+Se `getConsultantSummary` ou `getConsultantClients` retornar 403, exibir toast "Acesso negado" e opcionalmente redirecionar para `/`. Usar `onError` no useQuery ou verificar `error?.response?.status === 403` no componente.
+
+**Step 2: Estados vazios**
+
+Lista de clientes vazia: mensagem "Nenhum cliente vinculado". Summary com zeros: exibir normalmente.
+
+**Step 3: Commit**
+
+```bash
+git add src/pages/consultant/index.tsx src/hooks/useConsultantData.ts
+git commit -m "feat(consultant): error handling and empty states"
+```
+
+---
+
+## Task 9: Testes e validação final
+
+**Files:**
+- Create: `src/pages/consultant/__tests__/ConsultantDashboard.test.tsx` (opcional)
+- Modify: `test/mocks/handlers.ts` (mock dos endpoints de consultor)
+
+**Step 1: Mock MSW para consultant**
+
+Adicionar handlers para `GET /v1/consultant/summary` e `GET /v1/consultant/clients` em `test/mocks/handlers.ts`.
+
+**Step 2: Teste de integração (opcional)**
+
+Teste que verifica: usuário consultor vê redirect para /consultant; página consultant exibe summary e lista.
+
+**Step 3: Rodar suite completa**
+
+Run: `npm run test`  
+Run: `npm run check`  
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add test/mocks/handlers.ts
+git commit -m "test(consultant): add MSW handlers for consultant API"
+```
+
+---
+
+## Resumo de arquivos
+
+**Criar:**
+- `src/api/consultant.ts`
+- `src/lib/consultant.ts`
+- `src/lib/__tests__/consultant.test.ts`
+- `src/hooks/useConsultantData.ts`
+- `src/pages/consultant/index.tsx`
+- `src/components/consultant/ConsultantSummaryCards.tsx`
+- `src/components/consultant/ConsultantClientList.tsx`
+- `src/layouts/ConsultantClientLayout.tsx`
+
+**Modificar:**
+- `src/types/api.ts`
+- `src/hooks/useOrganization.ts`
+- `src/App.tsx`
+- `src/layouts/AppLayout.tsx`
+- `src/components/Breadcrumb.tsx` (ou novo ConsultantBreadcrumb)
+- `test/mocks/handlers.ts`

--- a/docs/plans/consultant-dashboard-full-implementation.md
+++ b/docs/plans/consultant-dashboard-full-implementation.md
@@ -1,0 +1,667 @@
+# Consultant Dashboard Full Implementation Plan
+
+## Overview
+
+This plan details the complete implementation of the consultant dashboard feature, including:
+- Updated sidebar menu items
+- Full API integration (11 endpoints)
+- KPI cards with financial metrics
+- Charts and visualizations
+- Date range and snapshot date pickers
+
+## Architecture
+
+### Data Flow
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Consultant Dashboard                         │
+│  ┌─────────────┐  ┌─────────────┐  ┌───────────────────────┐ │
+│  │ Date Range  │  │  Snapshot   │  │   Query Parameters    │ │
+│  │   Picker    │  │ Date Picker │  │   (date_start,        │ │
+│  └──────┬──────┘  └──────┬──────┘  │    date_end,         │ │
+│         │                │         │    as_of_date)        │ │
+│         └────────────────┼─────────┴───────────────────────┘ │
+│                          ▼                                      │
+│  ┌─────────────────────────────────────────────────────────────┐│
+│  │              useConsultantData Hook (Custom)                ││
+│  │  - useConsultantSummary()                                  ││
+│  │  - useConsultantClients()                                  ││
+│  │  - useFinancialHealthIndex()                               ││
+│  │  - useActiveGoalsCount()                                   ││
+│  │  - useTotalCreditCardDebt()                                ││
+│  │  - useCashFlow()                                           ││
+│  │  - useExpensesByCategory()                                 ││
+│  │  - useIncomeCommitment()                                   ││
+│  │  - useGoalsProgressByType()                                ││
+│  │  - useClientsAtRisk()                                      ││
+│  └────────────────────────────┬────────────────────────────────┘│
+└───────────────────────────────┼─────────────────────────────────┘
+                                ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                    API Client Layer                              │
+│  src/api/consultant.ts                                          │
+│  - getConsultantSummary()                                       │
+│  - getConsultantClients()                                       │
+│  - getFinancialHealthIndex()                                    │
+│  - getActiveGoalsCount()                                        │
+│  - getTotalCreditCardDebt()                                     │
+│  - getCashFlow()                                                │
+│  - getExpensesByCategory()                                      │
+│  - getIncomeCommitment()                                        │
+│  - getGoalsProgressByType()                                     │
+│  - getClientsAtRisk()                                           │
+└──────────────────────────────────────────────────────────────────┘
+                                ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                    Backend API (/v1/consultant/*)               │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## Implementation Steps
+
+### Phase 1: Core Infrastructure
+
+#### 1.1 Update Sidebar Menu Items
+**File:** `src/layouts/AppLayout.tsx`
+
+Add new menu items for consultant area:
+- Dashboard (`/consultant`)
+- Meus Clientes (`/consultant/clients`)
+- Relatórios (`/consultant/reports`)
+- Metas dos Clientes (`/consultant/clients-goals`)
+- Configurações (`/consultant/settings`)
+
+```typescript
+// New sidebar items to add:
+const consultantMenuItems = [
+  { href: '/consultant', icon: LayoutGrid, label: 'Dashboard' },
+  { href: '/consultant/clients', icon: Users, label: 'Meus Clientes' },
+  { href: '/consultant/reports', icon: PieChart, label: 'Relatórios' },
+  { href: '/consultant/clients-goals', icon: Target, label: 'Metas dos Clientes' },
+  { href: '/consultant/settings', icon: Settings, label: 'Configurações' },
+];
+```
+
+#### 1.2 Add TypeScript Types
+**File:** `src/types/api.ts`
+
+Add types for all consultant endpoints:
+
+```typescript
+// Query types
+export interface ConsultantSummaryQuery {
+  date_start?: string;
+  date_end?: string;
+}
+
+export interface ActiveGoalsCountQuery {
+  as_of_date?: string;
+}
+
+export interface TotalCreditCardDebtQuery {
+  as_of_date?: string;
+}
+
+export interface CashFlowQuery {
+  date_start?: string;
+  date_end?: string;
+}
+
+export interface ExpensesByCategoryQuery {
+  date_start?: string;
+  date_end?: string;
+}
+
+export interface IncomeCommitmentQuery {
+  date_start?: string;
+  date_end?: string;
+}
+
+export interface GoalsProgressByTypeQuery {
+  as_of_date?: string;
+}
+
+export interface ClientsAtRiskQuery {
+  as_of_date?: string;
+  limit?: number;
+  gasto_maior_renda_meses?: number;
+  endividamento_max_percent?: number;
+  exigir_reserva_emergencia?: boolean;
+}
+
+// Response types
+export interface FinancialHealthIndexResponse {
+  index: number;
+  balance_score: number;
+  debt_score: number;
+  reserve_score: number;
+  total_income: number;
+  total_expenses: number;
+  balance: number;
+  total_debt: number;
+  organizations_count: number;
+  period_start: string;
+  period_end: string;
+  formula_info: string;
+}
+
+export interface ActiveGoalsCountResponse {
+  active_goals_count: number;
+  organizations_count: number;
+  as_of_date: string;
+}
+
+export interface TotalCreditCardDebtResponse {
+  total_debt: number;
+  organizations_count: number;
+  as_of_date: string;
+}
+
+export interface MonthlyCashFlowItem {
+  month: string;
+  year: number;
+  month_number: number;
+  total_income: number;
+  total_expenses: number;
+  balance: number;
+}
+
+export interface CashFlowResponse {
+  monthly_data: MonthlyCashFlowItem[];
+  period_start: string;
+  period_end: string;
+}
+
+export interface CategoryExpenseItem {
+  name: string;
+  total: number;
+  percentage: number;
+}
+
+export interface ExpensesByCategoryResponse {
+  categories: CategoryExpenseItem[];
+  total_expenses: number;
+  period_start: string;
+  period_end: string;
+}
+
+export interface MonthlyIncomeCommitmentItem {
+  month: string;
+  year: number;
+  month_number: number;
+  income_commitment_percent: number;
+  total_income: number;
+  total_card_bills: number;
+}
+
+export interface IncomeCommitmentResponse {
+  monthly_data: MonthlyIncomeCommitmentItem[];
+  period_start: string;
+  period_end: string;
+}
+
+export interface GoalProgressByTypeItem {
+  goal_name: string;
+  avg_progress: number;
+  count: number;
+}
+
+export interface GoalsProgressByTypeResponse {
+  by_type: GoalProgressByTypeItem[];
+  organizations_count: number;
+  as_of_date: string;
+}
+
+export interface ClientAtRiskItem {
+  organization_id: string;
+  organization_name: string;
+  main_situation: string;
+  current_balance: number;
+  last_invoice_status: string;
+  risk_score: number;
+}
+
+export interface ClientsAtRiskResponse {
+  clients: ClientAtRiskItem[];
+  total: number;
+  as_of_date: string;
+}
+```
+
+#### 1.3 Implement API Endpoints
+**File:** `src/api/consultant.ts`
+
+Add all 8 missing API functions:
+
+```typescript
+export const getFinancialHealthIndex = async (
+  params?: ConsultantSummaryQuery
+): Promise<FinancialHealthIndexResponse> => {
+  const response = await apiClient.get<FinancialHealthIndexResponse>(
+    '/consultant/financial-health-index',
+    { params }
+  );
+  return response.data;
+};
+
+export const getActiveGoalsCount = async (
+  params?: ActiveGoalsCountQuery
+): Promise<ActiveGoalsCountResponse> => {
+  const response = await apiClient.get<ActiveGoalsCountResponse>(
+    '/consultant/active-goals-count',
+    { params }
+  );
+  return response.data;
+};
+
+export const getTotalCreditCardDebt = async (
+  params?: TotalCreditCardDebtQuery
+): Promise<TotalCreditCardDebtResponse> => {
+  const response = await apiClient.get<TotalCreditCardDebtResponse>(
+    '/consultant/total-credit-card-debt',
+    { params }
+  );
+  return response.data;
+};
+
+export const getCashFlow = async (
+  params?: CashFlowQuery
+): Promise<CashFlowResponse> => {
+  const response = await apiClient.get<CashFlowResponse>(
+    '/consultant/cash-flow',
+    { params }
+  );
+  return response.data;
+};
+
+export const getExpensesByCategory = async (
+  params?: ExpensesByCategoryQuery
+): Promise<ExpensesByCategoryResponse> => {
+  const response = await apiClient.get<ExpensesByCategoryResponse>(
+    '/consultant/expenses-by-category',
+    { params }
+  );
+  return response.data;
+};
+
+export const getIncomeCommitment = async (
+  params?: IncomeCommitmentQuery
+): Promise<IncomeCommitmentResponse> => {
+  const response = await apiClient.get<IncomeCommitmentResponse>(
+    '/consultant/income-commitment',
+    { params }
+  );
+  return response.data;
+};
+
+export const getGoalsProgressByType = async (
+  params?: GoalsProgressByTypeQuery
+): Promise<GoalsProgressByTypeResponse> => {
+  const response = await apiClient.get<GoalsProgressByTypeResponse>(
+    '/consultant/goals-progress-by-type',
+    { params }
+  );
+  return response.data;
+};
+
+export const getClientsAtRisk = async (
+  params?: ClientsAtRiskQuery
+): Promise<ClientsAtRiskResponse> => {
+  const response = await apiClient.get<ClientsAtRiskResponse>(
+    '/consultant/clients-at-risk',
+    { params }
+  );
+  return response.data;
+};
+```
+
+#### 1.4 Create Custom Hooks
+**File:** `src/hooks/useConsultantData.ts`
+
+Extend existing hooks and add new ones:
+
+```typescript
+// Existing hooks to extend
+export function useConsultantSummary(params?: ConsultantSummaryQuery) {
+  return useQuery({
+    queryKey: ['consultant-summary', params?.date_start, params?.date_end],
+    queryFn: () => getConsultantSummary(params),
+    retry: false,
+  });
+}
+
+export function useConsultantClients() {
+  return useQuery({
+    queryKey: ['consultant-clients'],
+    queryFn: getConsultantClients,
+    retry: false,
+  });
+}
+
+// New hooks to add
+export function useFinancialHealthIndex(params?: ConsultantSummaryQuery) {
+  return useQuery({
+    queryKey: ['consultant-financial-health', params?.date_start, params?.date_end],
+    queryFn: () => getFinancialHealthIndex(params),
+    retry: false,
+  });
+}
+
+export function useActiveGoalsCount(asOfDate?: string) {
+  return useQuery({
+    queryKey: ['consultant-active-goals', asOfDate],
+    queryFn: () => getActiveGoalsCount({ as_of_date: asOfDate }),
+    retry: false,
+  });
+}
+
+export function useTotalCreditCardDebt(asOfDate?: string) {
+  return useQuery({
+    queryKey: ['consultant-credit-card-debt', asOfDate],
+    queryFn: () => getTotalCreditCardDebt({ as_of_date: asOfDate }),
+    retry: false,
+  });
+}
+
+export function useCashFlow(params?: CashFlowQuery) {
+  return useQuery({
+    queryKey: ['consultant-cash-flow', params?.date_start, params?.date_end],
+    queryFn: () => getCashFlow(params),
+    retry: false,
+  });
+}
+
+export function useExpensesByCategory(params?: ExpensesByCategoryQuery) {
+  return useQuery({
+    queryKey: ['consultant-expenses-category', params?.date_start, params?.date_end],
+    queryFn: () => getExpensesByCategory(params),
+    retry: false,
+  });
+}
+
+export function useIncomeCommitment(params?: IncomeCommitmentQuery) {
+  return useQuery({
+    queryKey: ['consultant-income-commitment', params?.date_start, params?.date_end],
+    queryFn: () => getIncomeCommitment(params),
+    retry: false,
+  });
+}
+
+export function useGoalsProgressByType(asOfDate?: string) {
+  return useQuery({
+    queryKey: ['consultant-goals-progress', asOfDate],
+    queryFn: () => getGoalsProgressByType({ as_of_date: asOfDate }),
+    retry: false,
+  });
+}
+
+export function useClientsAtRisk(params?: ClientsAtRiskQuery) {
+  return useQuery({
+    queryKey: ['consultant-clients-at-risk', params?.as_of_date, params?.limit],
+    queryFn: () => getClientsAtRisk(params),
+    retry: false,
+  });
+}
+```
+
+### Phase 2: UI Components
+
+#### 2.1 KPI Cards Component
+**File:** `src/components/consultant/ConsultantKPICards.tsx`
+
+Update to show:
+- Total de Clientes (from `organizations_count`)
+- Índice de Saúde Financeira Médio (from `FinancialHealthIndexResponse.index`)
+- Dívida Total em Cartões (from `TotalCreditCardDebtResponse.total_debt`)
+- Metas de Economia em Progresso (from `ActiveGoalsCountResponse.active_goals_count`)
+
+```typescript
+interface ConsultantKPICardsProps {
+  summary?: ConsultantSummaryResponse;
+  healthIndex?: FinancialHealthIndexResponse;
+  creditCardDebt?: TotalCreditCardDebtResponse;
+  activeGoals?: ActiveGoalsCountResponse;
+  isLoading?: boolean;
+}
+
+// Layout: 4 cards in a row
+// Card 1: Clients (icon: Users)
+// Card 2: Financial Health Index (icon: Heart/Pulse) - show as percentage gauge
+// Card 3: Credit Card Debt (icon: CreditCard) - show as currency
+// Card 4: Active Goals (icon: Target)
+```
+
+#### 2.2 Financial Health Index Gauge
+**File:** `src/components/consultant/FinancialHealthGauge.tsx`
+
+A radial gauge showing:
+- Overall index (0-100)
+- Balance score
+- Debt score  
+- Reserve score
+
+```typescript
+interface FinancialHealthGaugeProps {
+  data?: FinancialHealthIndexResponse;
+  isLoading?: boolean;
+}
+
+// Implementation: Use radial bar chart or custom SVG gauge
+// Colors: Green (70+), Yellow (40-70), Red (<40)
+```
+
+#### 2.3 Cash Flow Chart
+**File:** `src/components/consultant/CashFlowChart.tsx`
+
+Bar chart showing monthly:
+- Income (green bars)
+- Expenses (red bars)
+- Balance line overlay
+
+```typescript
+interface CashFlowChartProps {
+  data?: CashFlowResponse;
+  isLoading?: boolean;
+}
+
+// Implementation: Use existing IncomeExpenseBarChart or create new
+```
+
+#### 2.4 Expenses by Category Pie Chart
+**File:** `src/components/consultant/ExpensesByCategoryChart.tsx`
+
+Pie/Donut chart showing expense distribution by category.
+
+```typescript
+interface ExpensesByCategoryChartProps {
+  data?: ExpensesByCategoryResponse;
+  isLoading?: boolean;
+}
+
+// Implementation: Use existing ExpensePieChart component
+```
+
+#### 2.5 Income Commitment Chart
+**File:** `src/components/consultant/IncomeCommitmentChart.tsx`
+
+Line/Area chart showing monthly income commitment percentage.
+
+```typescript
+interface IncomeCommitmentChartProps {
+  data?: IncomeCommitmentResponse;
+  isLoading?: boolean;
+}
+```
+
+#### 2.6 Goals Progress Chart
+**File:** `src/components/consultant/GoalsProgressChart.tsx`
+
+Horizontal bar chart showing progress by goal type.
+
+```typescript
+interface GoalsProgressChartProps {
+  data?: GoalsProgressByTypeResponse;
+  isLoading?: boolean;
+}
+```
+
+#### 2.7 Clients at Risk List
+**File:** `src/components/consultant/ClientsAtRiskList.tsx`
+
+List of clients with risk indicators:
+- Organization name
+- Risk score (with color coding)
+- Main situation
+- Current balance
+
+```typescript
+interface ClientsAtRiskListProps {
+  data?: ClientsAtRiskResponse;
+  isLoading?: boolean;
+}
+```
+
+#### 2.8 Date/Snapshot Picker Component
+**File:** `src/components/consultant/ConsultantDateControls.tsx`
+
+Combined controls for:
+- Date range picker (for period-based data)
+- Snapshot date picker (for point-in-time data)
+
+```typescript
+interface ConsultantDateControlsProps {
+  dateRange?: { from: Date; to: Date };
+  snapshotDate?: Date;
+  onDateRangeChange?: (range: { from: Date; to: Date } | undefined) => void;
+  onSnapshotDateChange?: (date: Date | undefined) => void;
+}
+
+// Implementation: Combine existing DateRangePicker with single date picker
+// Show/hide based on which data types need which
+```
+
+### Phase 3: Dashboard Integration
+
+#### 3.1 Update Consultant Dashboard Page
+**File:** `src/pages/consultant/index.tsx`
+
+Update to include all components:
+
+```tsx
+export default function ConsultantDashboard() {
+  // State for date controls
+  const [dateRange, setDateRange] = useState<DateRange>(...);
+  const [snapshotDate, setSnapshotDate] = useState<Date>(...);
+
+  // Query params construction
+  const periodParams = dateRange ? {
+    date_start: format(dateRange.from, 'yyyy-MM-dd'),
+    date_end: format(dateRange.to, 'yyyy-MM-dd'),
+  } : undefined;
+
+  const snapshotParams = snapshotDate 
+    ? { as_of_date: format(snapshotDate, 'yyyy-MM-dd') }
+    : undefined;
+
+  // Data fetching
+  const { data: summary } = useConsultantSummary(periodParams);
+  const { data: healthIndex } = useFinancialHealthIndex(periodParams);
+  const { data: creditCardDebt } = useTotalCreditCardDebt(snapshotDate ? format(snapshotDate, 'yyyy-MM-dd') : undefined);
+  const { data: activeGoals } = useActiveGoalsCount(snapshotDate ? format(snapshotDate, 'yyyy-MM-dd') : undefined);
+  const { data: cashFlow } = useCashFlow(periodParams);
+  const { data: expensesByCategory } = useExpensesByCategory(periodParams);
+  const { data: incomeCommitment } = useIncomeCommitment(periodParams);
+  const { data: goalsProgress } = useGoalsProgressByType(snapshotDate ? format(snapshotDate, 'yyyy-MM-dd') : undefined);
+  const { data: clientsAtRisk } = useClientsAtRisk({ ...snapshotParams, limit: 10 });
+  const { data: clients } = useConsultantClients();
+
+  return (
+    <PageTransition>
+      <div className="space-y-6">
+        {/* Date Controls */}
+        <ConsultantDateControls
+          dateRange={dateRange}
+          snapshotDate={snapshotDate}
+          onDateRangeChange={setDateRange}
+          onSnapshotDateChange={setSnapshotDate}
+        />
+
+        {/* KPI Cards Row */}
+        <ConsultantKPICards
+          summary={summary}
+          healthIndex={healthIndex}
+          creditCardDebt={creditCardDebt}
+          activeGoals={activeGoals}
+        />
+
+        {/* Charts Row 1 */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <CashFlowChart data={cashFlow} />
+          <ExpensesByCategoryChart data={expensesByCategory} />
+        </div>
+
+        {/* Charts Row 2 */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <FinancialHealthGauge data={healthIndex} />
+          <IncomeCommitmentChart data={incomeCommitment} />
+        </div>
+
+        {/* Goals Progress */}
+        <GoalsProgressChart data={goalsProgress} />
+
+        {/* Clients at Risk */}
+        <ClientsAtRiskList data={clientsAtRisk} />
+
+        {/* Client List */}
+        <ConsultantClientList clients={clients?.clients} />
+      </div>
+    </PageTransition>
+  );
+}
+```
+
+### Phase 4: Routing
+
+#### 4.1 Add New Routes
+**File:** `src/App.tsx`
+
+Add routes for new consultant pages:
+
+```tsx
+<Route path="/consultant/clients" component={ConsultantClientsPage} />
+<Route path="/consultant/reports" component={ConsultantReportsPage} />
+<Route path="/consultant/clients-goals" component={ConsultantClientsGoalsPage} />
+<Route path="/consultant/settings" component={ConsultantSettingsPage} />
+```
+
+### Phase 5: Testing
+
+#### 5.1 Test Coverage
+- Unit tests for all new hooks
+- Integration tests for API calls
+- Component tests for UI elements
+
+## Summary
+
+### Files to Create
+1. `src/components/consultant/ConsultantKPICards.tsx`
+2. `src/components/consultant/FinancialHealthGauge.tsx`
+3. `src/components/consultant/CashFlowChart.tsx`
+4. `src/components/consultant/ExpensesByCategoryChart.tsx`
+5. `src/components/consultant/IncomeCommitmentChart.tsx`
+6. `src/components/consultant/GoalsProgressChart.tsx`
+7. `src/components/consultant/ClientsAtRiskList.tsx`
+8. `src/components/consultant/ConsultantDateControls.tsx`
+
+### Files to Modify
+1. `src/types/api.ts` - Add TypeScript types
+2. `src/api/consultant.ts` - Add API functions
+3. `src/hooks/useConsultantData.ts` - Add hooks
+4. `src/layouts/AppLayout.tsx` - Update sidebar
+5. `src/pages/consultant/index.tsx` - Update dashboard
+6. `src/App.tsx` - Add routes
+
+### Dependencies
+- Reuse existing chart components from `src/components/charts/`
+- Reuse existing UI components from `src/components/ui/`
+- Use existing `DateRangePicker` component

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { Toaster as SonnerToaster } from "sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { lazy, Suspense } from "react";
 import { motion } from "framer-motion";
-import Dashboard from "@/pages/dashboard";
+import { DashboardOrRedirect } from "@/components/DashboardOrRedirect";
 import TransactionsPage from "@/pages/transactions";
 import CreditCardsPage from '@/pages/credit-cards';
 import InvoiceHistoryPage from '@/pages/credit-cards/history';
@@ -24,6 +24,8 @@ const ProfilePage = lazy(() => import("@/pages/profile"));
 const ChangePasswordPage = lazy(() => import("@/pages/profile/change-password"));
 const CreateOrganizationPage = lazy(() => import("@/pages/onboarding/create-organization"));
 const NoOrganizationPage = lazy(() => import("@/pages/no-organization"));
+const ConsultantDashboard = lazy(() => import("@/pages/consultant"));
+const ConsultantClientLayout = lazy(() => import("@/layouts/ConsultantClientLayout").then((m) => ({ default: m.ConsultantClientLayout })));
 
 // Loading fallback component with animation
 function PageLoader() {
@@ -48,7 +50,15 @@ function ProtectedRoutes() {
         <AppLayout>
           <Suspense fallback={<PageLoader />}>
             <Switch>
-              <Route path="/" component={Dashboard} />
+              <Route path="/" component={DashboardOrRedirect} />
+              <Route path="/consultant" component={ConsultantDashboard} />
+              <Route path="/consultant/clients/:organizationId" component={ConsultantClientLayout} />
+              <Route path="/consultant/clients/:organizationId/transactions" component={TransactionsPage} />
+              <Route path="/consultant/clients/:organizationId/credit-cards" component={CreditCardsPage} />
+              <Route path="/consultant/clients/:organizationId/credit-cards/history" component={InvoiceHistoryPage} />
+              <Route path="/consultant/clients/:organizationId/credit-cards/planning" component={FuturePlanningPage} />
+              <Route path="/consultant/clients/:organizationId/reports" component={ReportsPage} />
+              <Route path="/consultant/clients/:organizationId/goals" component={GoalsPage} />
               <Route path="/transactions" component={TransactionsPage} />
               <Route path="/credit-cards" component={CreditCardsPage} />
               <Route path="/credit-cards/history" component={InvoiceHistoryPage} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "@/pages/not-found";
 import AppLayout from "@/layouts/AppLayout";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
 import { RequireOrganization } from "@/components/RequireOrganization";
+import { RequireConsultant } from "@/components/RequireConsultant";
 
 // Lazy load heavy pages
 const ReportsPage = lazy(() => import("@/pages/reports"));
@@ -25,6 +26,7 @@ const ChangePasswordPage = lazy(() => import("@/pages/profile/change-password"))
 const CreateOrganizationPage = lazy(() => import("@/pages/onboarding/create-organization"));
 const NoOrganizationPage = lazy(() => import("@/pages/no-organization"));
 const ConsultantDashboard = lazy(() => import("@/pages/consultant"));
+const ConsultantClientsPage = lazy(() => import("@/pages/consultant/clients"));
 const ConsultantClientLayout = lazy(() => import("@/layouts/ConsultantClientLayout").then((m) => ({ default: m.ConsultantClientLayout })));
 
 // Loading fallback component with animation
@@ -47,36 +49,39 @@ function ProtectedRoutes() {
   return (
     <ProtectedRoute>
       <RequireOrganization>
-        <AppLayout>
-          <Suspense fallback={<PageLoader />}>
-            <Switch>
-              <Route path="/" component={DashboardOrRedirect} />
-              <Route path="/consultant" component={ConsultantDashboard} />
-              <Route path="/consultant/clients/:organizationId" component={ConsultantClientLayout} />
-              <Route path="/consultant/clients/:organizationId/transactions" component={TransactionsPage} />
-              <Route path="/consultant/clients/:organizationId/credit-cards" component={CreditCardsPage} />
-              <Route path="/consultant/clients/:organizationId/credit-cards/history" component={InvoiceHistoryPage} />
-              <Route path="/consultant/clients/:organizationId/credit-cards/planning" component={FuturePlanningPage} />
-              <Route path="/consultant/clients/:organizationId/reports" component={ReportsPage} />
-              <Route path="/consultant/clients/:organizationId/goals" component={GoalsPage} />
-              <Route path="/transactions" component={TransactionsPage} />
-              <Route path="/credit-cards" component={CreditCardsPage} />
-              <Route path="/credit-cards/history" component={InvoiceHistoryPage} />
-              <Route path="/credit-cards/planning" component={FuturePlanningPage} />
-              <Route path="/reports" component={ReportsPage} />
-              <Route path="/goals" component={GoalsPage} />
-              <Route path="/profile/change-password" component={ChangePasswordPage} />
-              <Route path="/profile/me" component={ProfilePage} />
-              <Route path="/profile/organizacoes" component={ProfilePage} />
-              <Route path="/profile/seguranca" component={ProfilePage} />
-              <Route path="/profile/whatsapp" component={ProfilePage} />
-              <Route path="/profile/categorias" component={ProfilePage} />
-              <Route path="/profile/assinatura" component={ProfilePage} />
-              <Route path="/profile" component={ProfilePage} />
-              <Route component={NotFound} />
-            </Switch>
-          </Suspense>
-        </AppLayout>
+        <RequireConsultant>
+          <AppLayout>
+            <Suspense fallback={<PageLoader />}>
+              <Switch>
+                <Route path="/" component={DashboardOrRedirect} />
+                <Route path="/consultant" component={ConsultantDashboard} />
+                <Route path="/consultant/clients" component={ConsultantClientsPage} />
+                <Route path="/consultant/clients/:organizationId" component={ConsultantClientLayout} />
+                <Route path="/consultant/clients/:organizationId/transactions" component={TransactionsPage} />
+                <Route path="/consultant/clients/:organizationId/credit-cards" component={CreditCardsPage} />
+                <Route path="/consultant/clients/:organizationId/credit-cards/history" component={InvoiceHistoryPage} />
+                <Route path="/consultant/clients/:organizationId/credit-cards/planning" component={FuturePlanningPage} />
+                <Route path="/consultant/clients/:organizationId/reports" component={ReportsPage} />
+                <Route path="/consultant/clients/:organizationId/goals" component={GoalsPage} />
+                <Route path="/transactions" component={TransactionsPage} />
+                <Route path="/credit-cards" component={CreditCardsPage} />
+                <Route path="/credit-cards/history" component={InvoiceHistoryPage} />
+                <Route path="/credit-cards/planning" component={FuturePlanningPage} />
+                <Route path="/reports" component={ReportsPage} />
+                <Route path="/goals" component={GoalsPage} />
+                <Route path="/profile/change-password" component={ChangePasswordPage} />
+                <Route path="/profile/me" component={ProfilePage} />
+                <Route path="/profile/organizacoes" component={ProfilePage} />
+                <Route path="/profile/seguranca" component={ProfilePage} />
+                <Route path="/profile/whatsapp" component={ProfilePage} />
+                <Route path="/profile/categorias" component={ProfilePage} />
+                <Route path="/profile/assinatura" component={ProfilePage} />
+                <Route path="/profile" component={ProfilePage} />
+                <Route component={NotFound} />
+              </Switch>
+            </Suspense>
+          </AppLayout>
+        </RequireConsultant>
       </RequireOrganization>
     </ProtectedRoute>
   );

--- a/src/api/consultant.ts
+++ b/src/api/consultant.ts
@@ -3,6 +3,21 @@ import type {
   ConsultantSummaryQuery,
   ConsultantSummaryResponse,
   ConsultantClientsResponse,
+  ActiveGoalsCountQuery,
+  ActiveGoalsCountResponse,
+  TotalCreditCardDebtQuery,
+  TotalCreditCardDebtResponse,
+  CashFlowQuery,
+  CashFlowResponse,
+  ExpensesByCategoryQuery,
+  ExpensesByCategoryResponse,
+  IncomeCommitmentQuery,
+  IncomeCommitmentResponse,
+  GoalsProgressByTypeQuery,
+  GoalsProgressByTypeResponse,
+  ClientsAtRiskQuery,
+  ClientsAtRiskResponse,
+  FinancialHealthIndexResponse,
 } from '../types/api';
 
 export const getConsultantSummary = async (
@@ -27,6 +42,86 @@ export const getConsultantConsolidatedReport = async (
 ): Promise<ConsultantSummaryResponse> => {
   const response = await apiClient.get<ConsultantSummaryResponse>(
     '/consultant/reports/consolidated',
+    { params }
+  );
+  return response.data;
+};
+
+export const getFinancialHealthIndex = async (
+  params?: ConsultantSummaryQuery
+): Promise<FinancialHealthIndexResponse> => {
+  const response = await apiClient.get<FinancialHealthIndexResponse>(
+    '/consultant/financial-health-index',
+    { params }
+  );
+  return response.data;
+};
+
+export const getActiveGoalsCount = async (
+  params?: ActiveGoalsCountQuery
+): Promise<ActiveGoalsCountResponse> => {
+  const response = await apiClient.get<ActiveGoalsCountResponse>(
+    '/consultant/active-goals-count',
+    { params }
+  );
+  return response.data;
+};
+
+export const getTotalCreditCardDebt = async (
+  params?: TotalCreditCardDebtQuery
+): Promise<TotalCreditCardDebtResponse> => {
+  const response = await apiClient.get<TotalCreditCardDebtResponse>(
+    '/consultant/total-credit-card-debt',
+    { params }
+  );
+  return response.data;
+};
+
+export const getCashFlow = async (
+  params?: CashFlowQuery
+): Promise<CashFlowResponse> => {
+  const response = await apiClient.get<CashFlowResponse>(
+    '/consultant/cash-flow',
+    { params }
+  );
+  return response.data;
+};
+
+export const getExpensesByCategory = async (
+  params?: ExpensesByCategoryQuery
+): Promise<ExpensesByCategoryResponse> => {
+  const response = await apiClient.get<ExpensesByCategoryResponse>(
+    '/consultant/expenses-by-category',
+    { params }
+  );
+  return response.data;
+};
+
+export const getIncomeCommitment = async (
+  params?: IncomeCommitmentQuery
+): Promise<IncomeCommitmentResponse> => {
+  const response = await apiClient.get<IncomeCommitmentResponse>(
+    '/consultant/income-commitment',
+    { params }
+  );
+  return response.data;
+};
+
+export const getGoalsProgressByType = async (
+  params?: GoalsProgressByTypeQuery
+): Promise<GoalsProgressByTypeResponse> => {
+  const response = await apiClient.get<GoalsProgressByTypeResponse>(
+    '/consultant/goals-progress-by-type',
+    { params }
+  );
+  return response.data;
+};
+
+export const getClientsAtRisk = async (
+  params?: ClientsAtRiskQuery
+): Promise<ClientsAtRiskResponse> => {
+  const response = await apiClient.get<ClientsAtRiskResponse>(
+    '/consultant/clients-at-risk',
     { params }
   );
   return response.data;

--- a/src/api/consultant.ts
+++ b/src/api/consultant.ts
@@ -1,0 +1,33 @@
+import apiClient from './client';
+import type {
+  ConsultantSummaryQuery,
+  ConsultantSummaryResponse,
+  ConsultantClientsResponse,
+} from '../types/api';
+
+export const getConsultantSummary = async (
+  params?: ConsultantSummaryQuery
+): Promise<ConsultantSummaryResponse> => {
+  const response = await apiClient.get<ConsultantSummaryResponse>(
+    '/consultant/summary',
+    { params }
+  );
+  return response.data;
+};
+
+export const getConsultantClients = async (): Promise<ConsultantClientsResponse> => {
+  const response = await apiClient.get<ConsultantClientsResponse>(
+    '/consultant/clients'
+  );
+  return response.data;
+};
+
+export const getConsultantConsolidatedReport = async (
+  params?: ConsultantSummaryQuery
+): Promise<ConsultantSummaryResponse> => {
+  const response = await apiClient.get<ConsultantSummaryResponse>(
+    '/consultant/reports/consolidated',
+    { params }
+  );
+  return response.data;
+};

--- a/src/components/DashboardOrRedirect.tsx
+++ b/src/components/DashboardOrRedirect.tsx
@@ -1,0 +1,17 @@
+import { Redirect } from 'wouter';
+import { useAuth } from '@/hooks/useAuth';
+import { isConsultant } from '@/lib/consultant';
+import Dashboard from '@/pages/dashboard';
+
+/**
+ * Renderiza o Dashboard ou redireciona para /consultant se o usuário for consultor
+ */
+export function DashboardOrRedirect() {
+  const { user } = useAuth();
+
+  if (isConsultant(user)) {
+    return <Redirect to="/consultant" />;
+  }
+
+  return <Dashboard />;
+}

--- a/src/components/DashboardOrRedirect.tsx
+++ b/src/components/DashboardOrRedirect.tsx
@@ -3,9 +3,6 @@ import { useAuth } from '@/hooks/useAuth';
 import { isConsultant } from '@/lib/consultant';
 import Dashboard from '@/pages/dashboard';
 
-/**
- * Renderiza o Dashboard ou redireciona para /consultant se o usuário for consultor
- */
 export function DashboardOrRedirect() {
   const { user } = useAuth();
 

--- a/src/components/DashboardOrRedirect.tsx
+++ b/src/components/DashboardOrRedirect.tsx
@@ -1,12 +1,17 @@
 import { Redirect } from 'wouter';
 import { useAuth } from '@/hooks/useAuth';
 import { isConsultant } from '@/lib/consultant';
+import { CONSULTANT_403_KEY } from '@/lib/permissions';
 import Dashboard from '@/pages/dashboard';
 
 export function DashboardOrRedirect() {
   const { user } = useAuth();
 
   if (isConsultant(user)) {
+    if (sessionStorage.getItem(CONSULTANT_403_KEY)) {
+      sessionStorage.removeItem(CONSULTANT_403_KEY);
+      return <Redirect to="/transactions" />;
+    }
     return <Redirect to="/consultant" />;
   }
 

--- a/src/components/PermissionGate.tsx
+++ b/src/components/PermissionGate.tsx
@@ -1,0 +1,13 @@
+import { type PropsWithChildren } from 'react';
+import { useCanAccess } from '@/hooks/useCanAccess';
+import type { Permission } from '@/lib/permissions';
+
+interface PermissionGateProps extends PropsWithChildren {
+  permission: Permission;
+  fallback?: React.ReactNode;
+}
+
+export function PermissionGate({ permission, children, fallback = null }: PermissionGateProps) {
+  const hasAccess = useCanAccess(permission);
+  return hasAccess ? <>{children}</> : <>{fallback}</>;
+}

--- a/src/components/RequireConsultant.tsx
+++ b/src/components/RequireConsultant.tsx
@@ -1,0 +1,20 @@
+import { type PropsWithChildren } from 'react';
+import { Redirect, useLocation } from 'wouter';
+import { useAuth } from '@/hooks/useAuth';
+import { canAccess } from '@/lib/permissions';
+
+export function RequireConsultant({ children }: PropsWithChildren) {
+  const [location] = useLocation();
+  const { user, loading } = useAuth();
+
+  // Wait for auth to load before checking permissions
+  if (loading) {
+    return null;
+  }
+
+  if (location.startsWith('/consultant') && !canAccess('consultant', user)) {
+    return <Redirect to="/" />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/RequireOrganization.tsx
+++ b/src/components/RequireOrganization.tsx
@@ -3,16 +3,8 @@ import { useLocation } from 'wouter';
 import { useAuth } from '@/hooks/useAuth';
 import { useOrganization } from '@/hooks/useOrganization';
 import { isConsultant } from '@/lib/consultant';
+import { CONSULTANT_403_KEY } from '@/lib/permissions';
 
-/**
- * Guard que verifica se o usuário possui pelo menos uma organização.
- *
- * Comportamento:
- * - Consultor sem organização → Redireciona para /consultant (acessa área consolidada)
- * - Owner sem organização → Redireciona para /onboarding/create-organization
- * - Member sem organização → Redireciona para /no-organization
- * - Usuário com organização → Permite acesso ao conteúdo
- */
 export function RequireOrganization({ children }: PropsWithChildren) {
   const [, setLocation] = useLocation();
   const { user } = useAuth();
@@ -23,7 +15,12 @@ export function RequireOrganization({ children }: PropsWithChildren) {
 
     if (organizations.length === 0) {
       if (isConsultant(user)) {
-        setLocation('/consultant');
+        if (sessionStorage.getItem(CONSULTANT_403_KEY)) {
+          sessionStorage.removeItem(CONSULTANT_403_KEY);
+          setLocation('/no-organization');
+        } else {
+          setLocation('/consultant');
+        }
       } else if (user.role === 'owner') {
         setLocation('/onboarding/create-organization');
       } else {
@@ -32,7 +29,6 @@ export function RequireOrganization({ children }: PropsWithChildren) {
     }
   }, [organizations, isLoading, user, setLocation]);
 
-  // Mostrar loading enquanto verifica
   if (isLoading) {
     return (
       <div className="flex items-center justify-center min-h-[60vh]">

--- a/src/components/RequireOrganization.tsx
+++ b/src/components/RequireOrganization.tsx
@@ -2,11 +2,13 @@ import { PropsWithChildren, useEffect } from 'react';
 import { useLocation } from 'wouter';
 import { useAuth } from '@/hooks/useAuth';
 import { useOrganization } from '@/hooks/useOrganization';
+import { isConsultant } from '@/lib/consultant';
 
 /**
  * Guard que verifica se o usuário possui pelo menos uma organização.
- * 
+ *
  * Comportamento:
+ * - Consultor sem organização → Redireciona para /consultant (acessa área consolidada)
  * - Owner sem organização → Redireciona para /onboarding/create-organization
  * - Member sem organização → Redireciona para /no-organization
  * - Usuário com organização → Permite acesso ao conteúdo
@@ -17,14 +19,12 @@ export function RequireOrganization({ children }: PropsWithChildren) {
   const { organizations, isLoading } = useOrganization();
 
   useEffect(() => {
-    // Aguardar carregamento das organizações
-    if (isLoading || !user) {
-      return;
-    }
+    if (isLoading || !user) return;
 
-    // Se não há organizações, redirecionar conforme o papel do usuário
     if (organizations.length === 0) {
-      if (user.role === 'owner') {
+      if (isConsultant(user)) {
+        setLocation('/consultant');
+      } else if (user.role === 'owner') {
         setLocation('/onboarding/create-organization');
       } else {
         setLocation('/no-organization');
@@ -44,12 +44,10 @@ export function RequireOrganization({ children }: PropsWithChildren) {
     );
   }
 
-  // Se tudo ok, renderizar conteúdo
-  if (organizations.length > 0) {
+  if (organizations.length > 0 || isConsultant(user)) {
     return <>{children}</>;
   }
 
-  // Caso contrário, não renderizar nada (redirecionamento será feito pelo useEffect)
   return null;
 }
 

--- a/src/components/consultant/CashFlowChart.tsx
+++ b/src/components/consultant/CashFlowChart.tsx
@@ -1,0 +1,61 @@
+import { TrendingUp } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { IncomeExpenseBarChart } from '@/components/charts/IncomeExpenseBarChart';
+import { ConsultantEmptyState } from '@/components/consultant/ConsultantEmptyState';
+import type { CashFlowResponse } from '@/types/api';
+
+interface CashFlowChartProps {
+  data?: CashFlowResponse;
+  isLoading?: boolean;
+}
+
+export function CashFlowChart({ data, isLoading }: CashFlowChartProps) {
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Fluxo de Caixa</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-[300px] w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!data || data.monthly_data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Fluxo de Caixa</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ConsultantEmptyState
+            icon={TrendingUp}
+            title="Nenhum dado de fluxo de caixa"
+            description="Registre receitas e despesas para visualizar o fluxo de caixa consolidado dos seus clientes."
+          />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Transform data for the bar chart
+  const chartData = data.monthly_data.map((item) => ({
+    month: item.month,
+    income: item.total_income,
+    expenses: item.total_expenses,
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Fluxo de Caixa</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <IncomeExpenseBarChart data={chartData} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/consultant/ClientsAtRiskList.tsx
+++ b/src/components/consultant/ClientsAtRiskList.tsx
@@ -1,0 +1,128 @@
+import { AlertTriangle, CheckCircle, XCircle } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ConsultantEmptyState } from '@/components/consultant/ConsultantEmptyState';
+import { Skeleton } from '@/components/ui/skeleton';
+import { formatCurrency } from '@/lib/utils';
+import type { ClientsAtRiskResponse } from '@/types/api';
+
+interface ClientsAtRiskListProps {
+  data?: ClientsAtRiskResponse;
+  isLoading?: boolean;
+}
+
+export function ClientsAtRiskList({ data, isLoading }: ClientsAtRiskListProps) {
+  
+  // Get risk level color based on score
+  const getRiskColor = (score: number) => {
+    if (score >= 70) return 'text-red-500';
+    if (score >= 40) return 'text-yellow-500';
+    return 'text-green-500';
+  };
+
+  // Get risk level bg color
+  const getRiskBgColor = (score: number) => {
+    if (score >= 70) return 'bg-red-500/10';
+    if (score >= 40) return 'bg-yellow-500/10';
+    return 'bg-green-500/10';
+  };
+
+  // Get invoice status icon
+  const getInvoiceStatusIcon = (status: string) => {
+    switch (status) {
+      case 'paid':
+        return <CheckCircle className="h-4 w-4 text-green-500" />;
+      case 'unpaid':
+        return <XCircle className="h-4 w-4 text-red-500" />;
+      default:
+        return <AlertTriangle className="h-4 w-4 text-yellow-500" />;
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Card className="mt-8">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-yellow-500" />
+            Clientes em Risco
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {[1, 2, 3].map((i) => (
+              <Skeleton key={i} className="h-20 w-full" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!data || data.clients.length === 0) {
+    return (
+      <Card className="mt-8">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-green-500" />
+            Clientes em Risco
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ConsultantEmptyState
+            icon={CheckCircle}
+            title="Nenhum cliente em risco"
+            description="Ótimo! Todos os seus clientes estão com a saúde financeira em dia no momento."
+          />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="mt-8">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <AlertTriangle className="h-5 w-5 text-yellow-500" />
+          Clientes em Risco
+          <span className="text-sm font-normal text-muted-foreground ml-2">
+            ({data.total} {data.total === 1 ? 'cliente' : 'clientes'})
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {data.clients.map((client) => (
+            <div
+              key={client.organization_id}
+              className={`flex items-center justify-between p-4 rounded-lg ${getRiskBgColor(client.risk_score)} border border-border/50`}
+            >
+              <div className="flex items-center gap-4">
+                <div className={`text-2xl font-bold ${getRiskColor(client.risk_score)}`}>
+                  {client.risk_score}
+                </div>
+                <div>
+                  <p className="font-medium">{client.organization_name}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {client.main_situation}
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-6">
+                <div className="text-right">
+                  <p className="text-sm text-muted-foreground">Saldo</p>
+                  <p className={`font-medium ${client.current_balance < 0 ? 'text-red-500' : ''}`}>
+                    {formatCurrency(client.current_balance)}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-muted-foreground">Fatura:</span>
+                  {getInvoiceStatusIcon(client.last_invoice_status)}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/consultant/ConsultantBreadcrumb.tsx
+++ b/src/components/consultant/ConsultantBreadcrumb.tsx
@@ -34,7 +34,7 @@ export function ConsultantBreadcrumb() {
       {isClientView && (
         <>
           <ChevronRight className="w-4 h-4 shrink-0" />
-          <Link href={`/consultant/clients/${clientMatch![1]}`}>
+          <Link href={`/consultant/clients/${clientMatch?.[1] ?? ''}`}>
             <a className="hover:text-foreground transition-colors truncate max-w-[180px]">
               {activeOrganization?.name ?? 'Cliente'}
             </a>

--- a/src/components/consultant/ConsultantBreadcrumb.tsx
+++ b/src/components/consultant/ConsultantBreadcrumb.tsx
@@ -1,0 +1,51 @@
+import { Link, useLocation } from 'wouter';
+import { ChevronRight } from 'lucide-react';
+import { useOrganization } from '@/hooks/useOrganization';
+
+/**
+ * Breadcrumb para rotas do consultor: Consultor > [Cliente] > [Página]
+ */
+export function ConsultantBreadcrumb() {
+  const [location] = useLocation();
+  const { activeOrganization } = useOrganization();
+
+  if (!location.startsWith('/consultant')) return null;
+
+  const clientMatch = /^\/consultant\/clients\/([^/]+)(?:\/(.+))?/.exec(location);
+  const isClientView = !!clientMatch;
+  const subPath = clientMatch?.[2]; // ex: "transactions", "credit-cards/history"
+
+  const pageLabels: Record<string, string> = {
+    transactions: 'Transações',
+    'credit-cards': 'Cartões',
+    'credit-cards/history': 'Histórico de Faturas',
+    'credit-cards/planning': 'Planejamento',
+    reports: 'Relatórios',
+    goals: 'Metas',
+  };
+  const currentPageLabel = subPath ? pageLabels[subPath] ?? subPath : 'Dashboard';
+
+  return (
+    <nav className="flex items-center gap-1.5 text-sm text-muted-foreground" aria-label="Breadcrumb">
+      {isClientView ? (
+        <Link href="/consultant">
+          <a className="hover:text-foreground transition-colors">Consultor</a>
+        </Link>
+      ) : (
+        <span className="text-foreground font-medium">Consultor</span>
+      )}
+      {isClientView && (
+        <>
+          <ChevronRight className="w-4 h-4 shrink-0" />
+          <Link href={`/consultant/clients/${clientMatch![1]}`}>
+            <a className="hover:text-foreground transition-colors truncate max-w-[180px]">
+              {activeOrganization?.name ?? 'Cliente'}
+            </a>
+          </Link>
+          <ChevronRight className="w-4 h-4 shrink-0" />
+          <span className="text-foreground font-medium truncate">{currentPageLabel}</span>
+        </>
+      )}
+    </nav>
+  );
+}

--- a/src/components/consultant/ConsultantBreadcrumb.tsx
+++ b/src/components/consultant/ConsultantBreadcrumb.tsx
@@ -2,9 +2,6 @@ import { Link, useLocation } from 'wouter';
 import { ChevronRight } from 'lucide-react';
 import { useOrganization } from '@/hooks/useOrganization';
 
-/**
- * Breadcrumb para rotas do consultor: Consultor > [Cliente] > [Página]
- */
 export function ConsultantBreadcrumb() {
   const [location] = useLocation();
   const { activeOrganization } = useOrganization();
@@ -13,7 +10,7 @@ export function ConsultantBreadcrumb() {
 
   const clientMatch = /^\/consultant\/clients\/([^/]+)(?:\/(.+))?/.exec(location);
   const isClientView = !!clientMatch;
-  const subPath = clientMatch?.[2]; // ex: "transactions", "credit-cards/history"
+  const subPath = clientMatch?.[2];
 
   const pageLabels: Record<string, string> = {
     transactions: 'Transações',

--- a/src/components/consultant/ConsultantClientList.tsx
+++ b/src/components/consultant/ConsultantClientList.tsx
@@ -43,7 +43,10 @@ export function ConsultantClientList({ clients, isLoading }: ConsultantClientLis
             key={client.organization_id}
             href={`/consultant/clients/${client.organization_id}`}
           >
-            <a className="flex items-center justify-between p-4 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors group">
+            <a
+              className="flex items-center justify-between p-4 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors group"
+              aria-label={`Ver detalhes de ${client.organization_name}`}
+            >
               <div className="min-w-0 flex-1">
                 <p className="font-medium truncate">{client.organization_name}</p>
                 <p className="text-sm text-muted-foreground">
@@ -53,7 +56,7 @@ export function ConsultantClientList({ clients, isLoading }: ConsultantClientLis
                   })}
                 </p>
               </div>
-              <ChevronRight className="w-5 h-5 text-muted-foreground group-hover:text-foreground shrink-0 ml-2" />
+              <ChevronRight className="w-5 h-5 text-muted-foreground group-hover:text-foreground shrink-0 ml-2" aria-hidden />
             </a>
           </Link>
         ))}

--- a/src/components/consultant/ConsultantClientList.tsx
+++ b/src/components/consultant/ConsultantClientList.tsx
@@ -1,0 +1,63 @@
+import { Link } from 'wouter';
+import { ChevronRight } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import type { ConsultantClient } from '@/types/api';
+
+interface ConsultantClientListProps {
+  clients: ConsultantClient[];
+  isLoading?: boolean;
+}
+
+export function ConsultantClientList({ clients, isLoading }: ConsultantClientListProps) {
+  if (isLoading) {
+    return (
+      <Card className="p-6 rounded-2xl shadow-flat border-0">
+        <h3 className="text-lg font-semibold mb-4">Clientes</h3>
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-14 w-full rounded-lg" />
+          ))}
+        </div>
+      </Card>
+    );
+  }
+
+  if (clients.length === 0) {
+    return (
+      <Card className="p-6 rounded-2xl shadow-flat border-0">
+        <h3 className="text-lg font-semibold mb-4">Clientes</h3>
+        <p className="text-sm text-muted-foreground">Nenhum cliente vinculado.</p>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="p-6 rounded-2xl shadow-flat border-0">
+      <h3 className="text-lg font-semibold mb-4">Clientes ({clients.length})</h3>
+      <div className="space-y-2">
+        {clients.map((client) => (
+          <Link
+            key={client.organization_id}
+            href={`/consultant/clients/${client.organization_id}`}
+          >
+            <a className="flex items-center justify-between p-4 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors group">
+              <div className="min-w-0 flex-1">
+                <p className="font-medium truncate">{client.organization_name}</p>
+                <p className="text-sm text-muted-foreground">
+                  {client.role === 'owner' ? 'Proprietário' : 'Membro'} · desde{' '}
+                  {format(new Date(client.membership_created_at), "dd 'de' MMM yyyy", {
+                    locale: ptBR,
+                  })}
+                </p>
+              </div>
+              <ChevronRight className="w-5 h-5 text-muted-foreground group-hover:text-foreground shrink-0 ml-2" />
+            </a>
+          </Link>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/src/components/consultant/ConsultantClientList.tsx
+++ b/src/components/consultant/ConsultantClientList.tsx
@@ -1,7 +1,8 @@
 import { Link } from 'wouter';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, Users } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { ConsultantEmptyState } from '@/components/consultant/ConsultantEmptyState';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import type { ConsultantClient } from '@/types/api';
@@ -29,7 +30,11 @@ export function ConsultantClientList({ clients, isLoading }: ConsultantClientLis
     return (
       <Card className="p-6 rounded-2xl shadow-flat border-0">
         <h3 className="text-lg font-semibold mb-4">Clientes</h3>
-        <p className="text-sm text-muted-foreground">Nenhum cliente vinculado.</p>
+        <ConsultantEmptyState
+          icon={Users}
+          title="Nenhum cliente vinculado"
+          description="Os clientes que você atender aparecerão aqui. Compartilhe o link de convite para começar."
+        />
       </Card>
     );
   }

--- a/src/components/consultant/ConsultantDateControls.tsx
+++ b/src/components/consultant/ConsultantDateControls.tsx
@@ -1,0 +1,135 @@
+import { Calendar as CalendarIcon } from 'lucide-react';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { DateRange } from 'react-day-picker';
+import { cn } from '@/lib/utils';
+
+interface ConsultantDateControlsProps {
+  dateRange?: DateRange;
+  snapshotDate?: Date;
+  onDateRangeChange?: (range: DateRange | undefined) => void;
+  onSnapshotDateChange?: (date: Date | undefined) => void;
+}
+
+export function ConsultantDateControls({
+  dateRange,
+  snapshotDate,
+  onDateRangeChange,
+  onSnapshotDateChange,
+}: ConsultantDateControlsProps) {
+  // datePickerMode reserved for future use (single/range toggle)
+
+  return (
+    <div className="flex flex-wrap items-center gap-4 mb-6">
+      {/* Date Range Picker */}
+      <div className="flex items-center gap-2">
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button
+              variant={"outline"}
+              className={cn(
+                "w-[280px] justify-start text-left font-normal",
+                !dateRange && "text-muted-foreground"
+              )}
+            >
+              <CalendarIcon className="mr-2 h-4 w-4" />
+              {dateRange?.from ? (
+                dateRange.to ? (
+                  <>
+                    {format(dateRange.from, "dd MMM yyyy", { locale: ptBR })} -{" "}
+                    {format(dateRange.to, "dd MMM yyyy", { locale: ptBR })}
+                  </>
+                ) : (
+                  format(dateRange.from, "dd MMM yyyy", { locale: ptBR })
+                )
+              ) : (
+                <span>Selecione o período</span>
+              )}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align="start">
+            <Calendar
+              initialFocus
+              mode="range"
+              defaultMonth={dateRange?.from}
+              selected={dateRange}
+              onSelect={(range) => {
+                onDateRangeChange?.(range);
+              }}
+              numberOfMonths={2}
+              locale={ptBR}
+            />
+          </PopoverContent>
+        </Popover>
+        
+        {/* Clear date range button */}
+        {dateRange?.from && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onDateRangeChange?.(undefined)}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            Limpar
+          </Button>
+        )}
+      </div>
+
+      {/* Divider */}
+      <div className="h-8 w-px bg-border hidden sm:block" />
+
+      {/* Snapshot Date Picker */}
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-muted-foreground whitespace-nowrap">
+          Data base:
+        </span>
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button
+              variant={"outline"}
+              className={cn(
+                "w-[180px] justify-start text-left font-normal",
+                !snapshotDate && "text-muted-foreground"
+              )}
+            >
+              <CalendarIcon className="mr-2 h-4 w-4" />
+              {snapshotDate ? (
+                format(snapshotDate, "dd MMM yyyy", { locale: ptBR })
+              ) : (
+                <span>Hoje</span>
+              )}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align="start">
+            <Calendar
+              mode="single"
+              selected={snapshotDate}
+              onSelect={(date) => {
+                onSnapshotDateChange?.(date);
+              }}
+              initialFocus
+              locale={ptBR}
+            />
+          </PopoverContent>
+        </Popover>
+
+        {/* Set to today button */}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onSnapshotDateChange?.(new Date())}
+          className="text-muted-foreground hover:text-foreground"
+        >
+          Hoje
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/consultant/ConsultantEmptyState.tsx
+++ b/src/components/consultant/ConsultantEmptyState.tsx
@@ -1,0 +1,29 @@
+import { LucideIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface ConsultantEmptyStateProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  className?: string;
+}
+
+export function ConsultantEmptyState({ icon: Icon, title, description, className }: ConsultantEmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center py-12 px-6 rounded-xl',
+        'bg-gradient-to-br from-slate-50 via-white to-indigo-50/30',
+        'border border-slate-200/80',
+        'min-h-[200px]',
+        className
+      )}
+    >
+      <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-gradient-to-br from-indigo-100 to-cyan-100 mb-4 shadow-sm">
+        <Icon className="w-7 h-7 text-indigo-600/80" strokeWidth={1.5} />
+      </div>
+      <h3 className="text-base font-semibold text-slate-800 mb-1">{title}</h3>
+      <p className="text-sm text-slate-500 text-center max-w-[260px] leading-relaxed">{description}</p>
+    </div>
+  );
+}

--- a/src/components/consultant/ConsultantKPICards.tsx
+++ b/src/components/consultant/ConsultantKPICards.tsx
@@ -1,0 +1,119 @@
+import { Heart, CreditCard, Target, Users } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { formatCurrency } from '@/lib/utils';
+import type { 
+  ConsultantSummaryResponse,
+  FinancialHealthIndexResponse,
+  TotalCreditCardDebtResponse,
+  ActiveGoalsCountResponse
+} from '@/types/api';
+
+interface ConsultantKPICardsProps {
+  summary?: ConsultantSummaryResponse;
+  healthIndex?: FinancialHealthIndexResponse;
+  creditCardDebt?: TotalCreditCardDebtResponse;
+  activeGoals?: ActiveGoalsCountResponse;
+  isLoading?: boolean;
+}
+
+export function ConsultantKPICards({ 
+  summary, 
+  healthIndex, 
+  creditCardDebt, 
+  activeGoals,
+  isLoading 
+}: ConsultantKPICardsProps) {
+  
+  // Get health index label and color based on score
+  const getHealthLabel = (index: number) => {
+    if (index >= 70) return 'Saudável';
+    if (index >= 40) return 'Atenção';
+    return 'Risco';
+  };
+
+  const count = summary?.organizations_count ?? 0;
+  const healthIdx = healthIndex?.index ?? 0;
+  const debt = creditCardDebt?.total_debt ?? 0;
+  const goalsCount = activeGoals?.active_goals_count ?? 0;
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+      {/* Card 1: Total de Clientes */}
+      <Card className="p-6 rounded-2xl shadow-flat shadow-flat-hover border-0 kpi-card kpi-clients">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-white/90 mb-1">Total de Clientes</p>
+            {isLoading ? (
+              <Skeleton className="h-8 w-28 bg-white/30" />
+            ) : (
+              <p className="text-2xl font-bold text-white">
+                {count} {count === 1 ? 'Cliente Ativo' : 'Clientes Ativos'}
+              </p>
+            )}
+          </div>
+          <div className="bg-white/20 p-3 rounded-xl ring-1 ring-white/40">
+            <Users className="text-white w-6 h-6" />
+          </div>
+        </div>
+      </Card>
+
+      {/* Card 2: Índice de Saúde Financeira Médio */}
+      <Card className="p-6 rounded-2xl shadow-flat shadow-flat-hover border-0 kpi-card kpi-health">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-white/90 mb-1">Índice de Saúde Financeira Médio</p>
+            {isLoading ? (
+              <Skeleton className="h-8 w-28 bg-white/30" />
+            ) : (
+              <p className="text-2xl font-bold text-white">
+                {healthIdx.toFixed(1)}/100 ({getHealthLabel(healthIdx)})
+              </p>
+            )}
+          </div>
+          <div className="bg-white/20 p-3 rounded-xl ring-1 ring-white/40">
+            <Heart className="text-white w-6 h-6" />
+          </div>
+        </div>
+      </Card>
+
+      {/* Card 3: Dívida Total em Cartões (Base) */}
+      <Card className="p-6 rounded-2xl shadow-flat shadow-flat-hover border-0 kpi-card kpi-debt">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-white/90 mb-1">Dívida Total em Cartões (Base)</p>
+            {isLoading ? (
+              <Skeleton className="h-8 w-32 bg-white/30" />
+            ) : (
+              <p className="text-2xl font-bold text-white">
+                {formatCurrency(debt)}
+              </p>
+            )}
+          </div>
+          <div className="bg-white/20 p-3 rounded-xl ring-1 ring-white/40">
+            <CreditCard className="text-white w-6 h-6" />
+          </div>
+        </div>
+      </Card>
+
+      {/* Card 4: Metas de Economia em Progresso */}
+      <Card className="p-6 rounded-2xl shadow-flat shadow-flat-hover border-0 kpi-card kpi-goals">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-white/90 mb-1">Metas de Economia em Progresso</p>
+            {isLoading ? (
+              <Skeleton className="h-8 w-28 bg-white/30" />
+            ) : (
+              <p className="text-2xl font-bold text-white">
+                {goalsCount} {goalsCount === 1 ? 'Meta Ativa' : 'Metas Ativas'}
+              </p>
+            )}
+          </div>
+          <div className="bg-white/20 p-3 rounded-xl ring-1 ring-white/40">
+            <Target className="text-white w-6 h-6" />
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/consultant/ConsultantSummaryCards.tsx
+++ b/src/components/consultant/ConsultantSummaryCards.tsx
@@ -1,0 +1,106 @@
+import { ArrowDown, Wallet, TrendingUp, Users, ListOrdered } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { formatCurrency } from '@/lib/utils';
+import type { ConsultantSummaryResponse } from '@/types/api';
+
+interface ConsultantSummaryCardsProps {
+  summary: ConsultantSummaryResponse | undefined;
+  isLoading?: boolean;
+}
+
+export function ConsultantSummaryCards({ summary, isLoading }: ConsultantSummaryCardsProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6 mb-8">
+      <Card className="p-6 rounded-2xl shadow-flat shadow-flat-hover border-0 kpi-card kpi-balance">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-white/90 mb-1">Balanço</p>
+            {isLoading ? (
+              <Skeleton className="h-8 w-40" />
+            ) : (
+              <p className="text-3xl font-semibold text-white">
+                {formatCurrency(summary?.balance ?? 0)}
+              </p>
+            )}
+          </div>
+          <div className="bg-white/20 p-3 rounded-xl ring-1 ring-white/40">
+            <Wallet className="text-white w-6 h-6" />
+          </div>
+        </div>
+      </Card>
+
+      <Card className="p-6 rounded-2xl shadow-flat shadow-flat-hover border-0 kpi-card kpi-income">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-white/90 mb-1">Receitas</p>
+            {isLoading ? (
+              <Skeleton className="h-8 w-40" />
+            ) : (
+              <p className="text-3xl font-semibold text-white">
+                {formatCurrency(summary?.total_income ?? 0)}
+              </p>
+            )}
+          </div>
+          <div className="bg-white/20 p-3 rounded-xl ring-1 ring-white/40">
+            <TrendingUp className="text-white w-6 h-6" />
+          </div>
+        </div>
+      </Card>
+
+      <Card className="p-6 rounded-2xl shadow-flat shadow-flat-hover border-0 kpi-card kpi-expense">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-white/90 mb-1">Despesas</p>
+            {isLoading ? (
+              <Skeleton className="h-8 w-40" />
+            ) : (
+              <p className="text-3xl font-semibold text-white">
+                {formatCurrency(summary?.total_expenses ?? 0)}
+              </p>
+            )}
+          </div>
+          <div className="bg-white/20 p-3 rounded-xl ring-1 ring-white/40">
+            <ArrowDown className="text-white w-6 h-6" />
+          </div>
+        </div>
+      </Card>
+
+      <Card className="p-6 rounded-2xl shadow-flat shadow-flat-hover border-0 kpi-card kpi-savings">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-white/90 mb-1">Transações</p>
+            {isLoading ? (
+              <Skeleton className="h-8 w-40" />
+            ) : (
+              <p className="text-3xl font-semibold text-white">
+                {summary?.total_transactions ?? 0}
+              </p>
+            )}
+          </div>
+          <div className="bg-white/20 p-3 rounded-xl ring-1 ring-white/40">
+            <ListOrdered className="text-white w-6 h-6" />
+          </div>
+        </div>
+      </Card>
+
+      <Card className="p-6 rounded-2xl shadow-flat shadow-flat-hover border-0 kpi-card kpi-savings">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-white/90 mb-1">Clientes</p>
+            {isLoading ? (
+              <Skeleton className="h-8 w-40" />
+            ) : (
+              <p className="text-3xl font-semibold text-white">
+                {summary?.organizations_count ?? 0}
+              </p>
+            )}
+          </div>
+          <div className="bg-white/20 p-3 rounded-xl ring-1 ring-white/40">
+            <Users className="text-white w-6 h-6" />
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/consultant/ConsultantSummaryCards.tsx
+++ b/src/components/consultant/ConsultantSummaryCards.tsx
@@ -66,7 +66,7 @@ export function ConsultantSummaryCards({ summary, isLoading }: ConsultantSummary
         </div>
       </Card>
 
-      <Card className="p-6 rounded-2xl shadow-flat shadow-flat-hover border-0 kpi-card kpi-savings">
+      <Card className="p-6 rounded-2xl shadow-flat shadow-flat-hover border-0 kpi-card kpi-savings" role="group" aria-label="Total de transações">
         <div className="flex items-center justify-between">
           <div>
             <p className="text-xs uppercase tracking-wide text-white/90 mb-1">Transações</p>
@@ -84,7 +84,7 @@ export function ConsultantSummaryCards({ summary, isLoading }: ConsultantSummary
         </div>
       </Card>
 
-      <Card className="p-6 rounded-2xl shadow-flat shadow-flat-hover border-0 kpi-card kpi-savings">
+      <Card className="p-6 rounded-2xl shadow-flat shadow-flat-hover border-0 kpi-card kpi-balance" role="group" aria-label="Total de clientes">
         <div className="flex items-center justify-between">
           <div>
             <p className="text-xs uppercase tracking-wide text-white/90 mb-1">Clientes</p>

--- a/src/components/consultant/ExpensesByCategoryChart.tsx
+++ b/src/components/consultant/ExpensesByCategoryChart.tsx
@@ -1,0 +1,65 @@
+import { PieChart } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ExpensePieChart } from '@/components/charts/ExpensePieChart';
+import { ConsultantEmptyState } from '@/components/consultant/ConsultantEmptyState';
+import type { ExpensesByCategoryResponse } from '@/types/api';
+import { chartColors } from '@/lib/chartConfig';
+
+// Convert chartColors object to array for easier indexing
+const colorArray = Object.values(chartColors);
+
+interface ExpensesByCategoryChartProps {
+  data?: ExpensesByCategoryResponse;
+  isLoading?: boolean;
+}
+
+export function ExpensesByCategoryChart({ data, isLoading }: ExpensesByCategoryChartProps) {
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Despesas por Categoria</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-[300px] w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!data || data.categories.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Despesas por Categoria</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ConsultantEmptyState
+            icon={PieChart}
+            title="Nenhum dado de despesas"
+            description="Quando houver transações registradas, as despesas aparecerão aqui organizadas por categoria."
+          />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Transform data for the pie chart - add colors from chartColors
+  const chartData = data.categories.map((category, index) => ({
+    name: category.name,
+    amount: category.total,
+    color: colorArray[index % colorArray.length],
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Despesas por Categoria</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ExpensePieChart data={chartData} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/consultant/GoalsProgressChart.tsx
+++ b/src/components/consultant/GoalsProgressChart.tsx
@@ -1,0 +1,111 @@
+import { Target } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ConsultantEmptyState } from '@/components/consultant/ConsultantEmptyState';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Progress } from '@/components/ui/progress';
+import type { GoalsProgressByTypeResponse } from '@/types/api';
+
+interface GoalsProgressChartProps {
+  data?: GoalsProgressByTypeResponse;
+  isLoading?: boolean;
+}
+
+// Helper to translate goal names to Portuguese
+const translateGoalName = (name: string): string => {
+  const translations: Record<string, string> = {
+    reserva_emergencia: 'Reserva de Emergência',
+    viagem: 'Viagem',
+    carro: 'Carro',
+    casa: 'Casa',
+    educação: 'Educação',
+    investimento: 'Investimento',
+    aposentadoria: 'Aposentadoria',
+    outro: 'Outros',
+  };
+  return translations[name] || name;
+};
+
+export function GoalsProgressChart({ data, isLoading }: GoalsProgressChartProps) {
+  
+  // Get color based on progress
+  const getProgressColor = (progress: number) => {
+    if (progress >= 70) return 'bg-green-500';
+    if (progress >= 40) return 'bg-yellow-500';
+    return 'bg-red-500';
+  };
+
+  if (isLoading) {
+    return (
+      <Card className="mt-8">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Target className="h-5 w-5" />
+            Progresso das Metas
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {[1, 2, 3].map((i) => (
+              <Skeleton key={i} className="h-12 w-full" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!data || data.by_type.length === 0) {
+    return (
+      <Card className="mt-8">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Target className="h-5 w-5" />
+            Progresso das Metas
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ConsultantEmptyState
+            icon={Target}
+            title="Nenhum dado de metas"
+            description="Os clientes ainda não criaram metas. Quando definirem metas, o progresso aparecerá aqui."
+          />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="mt-8">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Target className="h-5 w-5" />
+          Progresso das Metas
+          <span className="text-sm font-normal text-muted-foreground ml-2">
+            ({data.organizations_count} {data.organizations_count === 1 ? 'cliente' : 'clientes'})
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-6">
+          {data.by_type.map((goalType, index) => (
+            <div key={index} className="space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="font-medium">{translateGoalName(goalType.goal_name)}</span>
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <span>{goalType.avg_progress.toFixed(1)}%</span>
+                  <span className="text-xs">({goalType.count} {goalType.count === 1 ? 'meta' : 'metas'})</span>
+                </div>
+              </div>
+              <Progress 
+                value={goalType.avg_progress} 
+                className="h-3"
+                // Note: The Progress component uses default color, 
+                // for custom colors we'd need to override with CSS or className
+              />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/__tests__/useOrganization.test.tsx
+++ b/src/hooks/__tests__/useOrganization.test.tsx
@@ -23,9 +23,12 @@ describe('useOrganization', () => {
             expect(result.current.organizations.length).toBeGreaterThan(0);
         });
 
+        await waitFor(() => {
+            expect(result.current.activeOrgId).toBe('org-123');
+        });
+
         expect(result.current.organizations).toHaveLength(1);
         expect(result.current.organizations[0].name).toBe('Test Organization');
-        expect(result.current.activeOrgId).toBe('org-123');
     });
 
     it('should switch organization', async () => {

--- a/src/hooks/useCanAccess.ts
+++ b/src/hooks/useCanAccess.ts
@@ -1,0 +1,7 @@
+import { useAuth } from '@/hooks/useAuth';
+import { canAccess, type Permission } from '@/lib/permissions';
+
+export function useCanAccess(permission: Permission): boolean {
+  const { user } = useAuth();
+  return canAccess(permission, user);
+}

--- a/src/hooks/useConsultantData.ts
+++ b/src/hooks/useConsultantData.ts
@@ -1,6 +1,26 @@
 import { useQuery } from '@tanstack/react-query';
-import { getConsultantSummary, getConsultantClients } from '@/api/consultant';
-import type { ConsultantSummaryQuery } from '@/types/api';
+import {
+  getConsultantSummary,
+  getConsultantClients,
+  getFinancialHealthIndex,
+  getActiveGoalsCount,
+  getTotalCreditCardDebt,
+  getCashFlow,
+  getExpensesByCategory,
+  getIncomeCommitment,
+  getGoalsProgressByType,
+  getClientsAtRisk,
+} from '@/api/consultant';
+import type {
+  ConsultantSummaryQuery,
+  ActiveGoalsCountQuery,
+  TotalCreditCardDebtQuery,
+  CashFlowQuery,
+  ExpensesByCategoryQuery,
+  IncomeCommitmentQuery,
+  GoalsProgressByTypeQuery,
+  ClientsAtRiskQuery,
+} from '@/types/api';
 
 export function useConsultantSummary(params?: ConsultantSummaryQuery) {
   return useQuery({
@@ -14,6 +34,70 @@ export function useConsultantClients() {
   return useQuery({
     queryKey: ['consultant-clients'],
     queryFn: getConsultantClients,
+    retry: false,
+  });
+}
+
+export function useFinancialHealthIndex(params?: ConsultantSummaryQuery) {
+  return useQuery({
+    queryKey: ['consultant-financial-health', params?.date_start, params?.date_end],
+    queryFn: () => getFinancialHealthIndex(params),
+    retry: false,
+  });
+}
+
+export function useActiveGoalsCount(params?: ActiveGoalsCountQuery) {
+  return useQuery({
+    queryKey: ['consultant-active-goals', params?.as_of_date],
+    queryFn: () => getActiveGoalsCount(params),
+    retry: false,
+  });
+}
+
+export function useTotalCreditCardDebt(params?: TotalCreditCardDebtQuery) {
+  return useQuery({
+    queryKey: ['consultant-credit-card-debt', params?.as_of_date],
+    queryFn: () => getTotalCreditCardDebt(params),
+    retry: false,
+  });
+}
+
+export function useCashFlow(params?: CashFlowQuery) {
+  return useQuery({
+    queryKey: ['consultant-cash-flow', params?.date_start, params?.date_end],
+    queryFn: () => getCashFlow(params),
+    retry: false,
+  });
+}
+
+export function useExpensesByCategory(params?: ExpensesByCategoryQuery) {
+  return useQuery({
+    queryKey: ['consultant-expenses-category', params?.date_start, params?.date_end],
+    queryFn: () => getExpensesByCategory(params),
+    retry: false,
+  });
+}
+
+export function useIncomeCommitment(params?: IncomeCommitmentQuery) {
+  return useQuery({
+    queryKey: ['consultant-income-commitment', params?.date_start, params?.date_end],
+    queryFn: () => getIncomeCommitment(params),
+    retry: false,
+  });
+}
+
+export function useGoalsProgressByType(params?: GoalsProgressByTypeQuery) {
+  return useQuery({
+    queryKey: ['consultant-goals-progress', params?.as_of_date],
+    queryFn: () => getGoalsProgressByType(params),
+    retry: false,
+  });
+}
+
+export function useClientsAtRisk(params?: ClientsAtRiskQuery) {
+  return useQuery({
+    queryKey: ['consultant-clients-at-risk', params?.as_of_date, params?.limit],
+    queryFn: () => getClientsAtRisk(params),
     retry: false,
   });
 }

--- a/src/hooks/useConsultantData.ts
+++ b/src/hooks/useConsultantData.ts
@@ -6,6 +6,7 @@ export function useConsultantSummary(params?: ConsultantSummaryQuery) {
   return useQuery({
     queryKey: ['consultant-summary', params?.date_start, params?.date_end],
     queryFn: () => getConsultantSummary(params),
+    retry: false,
   });
 }
 
@@ -13,5 +14,6 @@ export function useConsultantClients() {
   return useQuery({
     queryKey: ['consultant-clients'],
     queryFn: getConsultantClients,
+    retry: false,
   });
 }

--- a/src/hooks/useConsultantData.ts
+++ b/src/hooks/useConsultantData.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import { getConsultantSummary, getConsultantClients } from '@/api/consultant';
+import type { ConsultantSummaryQuery } from '@/types/api';
+
+export function useConsultantSummary(params?: ConsultantSummaryQuery) {
+  return useQuery({
+    queryKey: ['consultant-summary', params?.date_start, params?.date_end],
+    queryFn: () => getConsultantSummary(params),
+  });
+}
+
+export function useConsultantClients() {
+  return useQuery({
+    queryKey: ['consultant-clients'],
+    queryFn: getConsultantClients,
+  });
+}

--- a/src/hooks/useOrganization.ts
+++ b/src/hooks/useOrganization.ts
@@ -8,11 +8,9 @@ import { OrganizationWithMembership } from '@/types/api';
 const STORAGE_KEY = 'active_organization_id';
 
 /**
- * Hook para gerenciar a organização ativa do usuário
- * - Carrega organizações do backend
- * - Persiste seleção no localStorage
- * - Em rotas /consultant/clients/:organizationId, o ID da URL tem prioridade
- * - Fornece funções para trocar de organização
+ * Hook para gerenciar a organização ativa do usuário.
+ * Carrega organizações do backend, persiste seleção no localStorage.
+ * Em rotas /consultant/clients/:id, o ID da URL tem prioridade.
  */
 export function useOrganization() {
     const [location, setLocation] = useLocation();
@@ -68,8 +66,7 @@ export function useOrganization() {
     }, [activeOrgId, organizations, isLoading]);
 
     /**
-     * Troca a organização ativa
-     * Em rota de cliente do consultor, navega para a nova URL
+     * Troca a organização ativa. Em rota de cliente do consultor, atualiza a URL.
      */
     const selectOrganization = (organizationId: string) => {
         const exists = organizations.some((o) => o.organization.id === organizationId);
@@ -104,7 +101,7 @@ export function useOrganization() {
     const isOwner = activeOrganization?.membership.role === 'owner';
 
     return {
-        // Estado (effectiveOrgId: URL tem prioridade em rotas de cliente do consultor)
+        // Estado
         activeOrgId: effectiveOrgId,
         activeOrganization: activeOrganization?.organization || null,
         activeMembership: activeOrganization?.membership || null,

--- a/src/hooks/useOrganization.ts
+++ b/src/hooks/useOrganization.ts
@@ -1,6 +1,7 @@
 // hooks/useOrganization.ts
 import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { useLocation } from 'wouter';
 import { getMyOrganizations } from '@/api/organizations';
 import { OrganizationWithMembership } from '@/types/api';
 
@@ -10,13 +11,20 @@ const STORAGE_KEY = 'active_organization_id';
  * Hook para gerenciar a organização ativa do usuário
  * - Carrega organizações do backend
  * - Persiste seleção no localStorage
+ * - Em rotas /consultant/clients/:organizationId, o ID da URL tem prioridade
  * - Fornece funções para trocar de organização
  */
 export function useOrganization() {
+    const [location, setLocation] = useLocation();
+    const urlOrgIdMatch = /^\/consultant\/clients\/([^/]+)/.exec(location);
+    const urlOrgId = urlOrgIdMatch?.[1] ?? null;
+
     const [activeOrgId, setActiveOrgId] = useState<string | null>(() => {
         // Carregar do localStorage na inicialização
         return localStorage.getItem(STORAGE_KEY);
     });
+
+    const effectiveOrgId = urlOrgId ?? activeOrgId;
 
     // Carregar organizações do usuário
     const {
@@ -61,6 +69,7 @@ export function useOrganization() {
 
     /**
      * Troca a organização ativa
+     * Em rota de cliente do consultor, navega para a nova URL
      */
     const selectOrganization = (organizationId: string) => {
         const exists = organizations.some((o) => o.organization.id === organizationId);
@@ -71,6 +80,14 @@ export function useOrganization() {
 
         setActiveOrgId(organizationId);
         localStorage.setItem(STORAGE_KEY, organizationId);
+
+        if (urlOrgId) {
+            const newPath = location.replace(
+                /^\/consultant\/clients\/[^/]+/,
+                `/consultant/clients/${organizationId}`
+            );
+            setLocation(newPath);
+        }
         return true;
     };
 
@@ -78,7 +95,7 @@ export function useOrganization() {
      * Obtém dados completos da organização ativa
      */
     const activeOrganization = organizations.find(
-        (o) => o.organization.id === activeOrgId
+        (o) => o.organization.id === effectiveOrgId
     );
 
     /**
@@ -87,8 +104,8 @@ export function useOrganization() {
     const isOwner = activeOrganization?.membership.role === 'owner';
 
     return {
-        // Estado
-        activeOrgId,
+        // Estado (effectiveOrgId: URL tem prioridade em rotas de cliente do consultor)
+        activeOrgId: effectiveOrgId,
         activeOrganization: activeOrganization?.organization || null,
         activeMembership: activeOrganization?.membership || null,
         isOwner,

--- a/src/index.css
+++ b/src/index.css
@@ -180,6 +180,20 @@
     background-image: linear-gradient(135deg, #00C6B8 0%, #00A89C 100%);
   }
 
+  /* KPI Cards - Dashboard do Consultor */
+  .kpi-clients {
+    background-image: linear-gradient(135deg, #3B82F6 0%, #2563EB 100%);
+  }
+  .kpi-health {
+    background-image: linear-gradient(135deg, #10B981 0%, #059669 100%);
+  }
+  .kpi-debt {
+    background-image: linear-gradient(135deg, #EF4444 0%, #DC2626 100%);
+  }
+  .kpi-goals {
+    background-image: linear-gradient(135deg, #8B5CF6 0%, #7C3AED 100%);
+  }
+
   /* Sombra Flat 2.0 */
   .shadow-flat {
     box-shadow: 0 1px 0 rgba(16, 24, 40, 0.02), 0 1px 2px rgba(16, 24, 40, 0.06);

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -35,6 +35,7 @@ import {
 import { useAuth } from "@/hooks/useAuth";
 import { useOrganization } from "@/hooks/useOrganization";
 import { isConsultant } from "@/lib/consultant";
+import { ConsultantBreadcrumb } from "@/components/consultant/ConsultantBreadcrumb";
 import { NewTransactionSheet } from "@/components/NewTransactionSheet";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
@@ -268,9 +269,15 @@ export function AppLayout({ children }: PropsWithChildren) {
         <div className="sticky top-0 z-30">
           <header className="supports-[backdrop-filter]:bg-white/40 backdrop-blur border-b border-gray-200/60 dark:supports-[backdrop-filter]:bg-white/[0.03] dark:border-white/10 bg-transparent">
             <div className="h-16 px-3 sm:px-4 md:px-6 lg:px-8 xl:px-10 flex items-center gap-2 sm:gap-3 justify-between mx-auto max-w-7xl xl:max-w-[90rem] 2xl:max-w-[96rem] min-w-0">
-              <div className="flex items-center gap-2 sm:gap-3 min-w-0 flex-1 sm:flex-none">
-                <SidebarTrigger className="shrink-0" />
-                <div className="text-lg sm:text-xl md:text-2xl font-semibold tracking-tight truncate min-w-0">{pageTitle}</div>
+              <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3 min-w-0 flex-1 sm:flex-none">
+                <SidebarTrigger className="shrink-0 self-start sm:self-center" />
+                <div className="min-w-0 flex-1">
+                  {consultantUser && location.startsWith("/consultant") ? (
+                    <ConsultantBreadcrumb />
+                  ) : (
+                    <div className="text-lg sm:text-xl md:text-2xl font-semibold tracking-tight truncate">{pageTitle}</div>
+                  )}
+                </div>
                 <Button
                   onClick={() => setIsNewTransactionOpen(true)}
                   className="h-8 sm:h-9 px-2 sm:px-4 rounded-full shadow-sm bg-gradient-to-r from-[#4A56E2] to-[#00C6B8] hover:from-[#343D9B] hover:to-[#00A89C] text-white font-medium flex items-center gap-1 sm:gap-2 transition-all duration-200 hover:scale-105 active:scale-95 shrink-0"

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -34,7 +34,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useAuth } from "@/hooks/useAuth";
 import { useOrganization } from "@/hooks/useOrganization";
-import { isConsultant } from "@/lib/consultant";
+import { useCanAccess } from "@/hooks/useCanAccess";
+import { PermissionGate } from "@/components/PermissionGate";
 import { ConsultantBreadcrumb } from "@/components/consultant/ConsultantBreadcrumb";
 import { NewTransactionSheet } from "@/components/NewTransactionSheet";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -57,25 +58,19 @@ const ROUTE_TITLES: Record<string, string> = {
   '/profile/categorias': 'Configurações',
   '/profile/assinatura': 'Configurações',
   '/profile/change-password': 'Alterar Senha',
-  '/consultant': 'Consultor',
+  '/consultant': 'Dashboard',
+  '/consultant/clients': 'Meus Clientes',
+  '/consultant/reports': 'Relatórios',
+  '/consultant/clients-goals': 'Metas dos Clientes',
 };
 
-/**
- * Obtém o título da página baseado na rota atual
- * Verifica rotas específicas primeiro, depois rotas principais
- */
 function getPageTitle(location: string): string {
-  // Verificar rota exata primeiro (para rotas aninhadas)
-  if (ROUTE_TITLES[location]) {
-    return ROUTE_TITLES[location];
-  }
-  // Rotas de cliente do consultor
+  if (ROUTE_TITLES[location]) return ROUTE_TITLES[location];
   if (/^\/consultant\/clients\/[^/]+$/.test(location)) return 'Dashboard';
   if (/^\/consultant\/clients\/[^/]+\/transactions/.test(location)) return 'Transações';
   if (/^\/consultant\/clients\/[^/]+\/credit-cards/.test(location)) return 'Cartões';
   if (/^\/consultant\/clients\/[^/]+\/reports/.test(location)) return 'Relatórios';
   if (/^\/consultant\/clients\/[^/]+\/goals/.test(location)) return 'Metas';
-  // Fallback
   return 'Dashboard';
 }
 
@@ -87,6 +82,9 @@ export function AppLayout({ children }: PropsWithChildren) {
   const [location, setLocation] = useLocation();
   const [isDashboard] = useRoute("/");
   const [isConsultantDashboard] = useRoute("/consultant");
+  const [isConsultantClients] = useRoute("/consultant/clients");
+  const [isConsultantReports] = useRoute("/consultant/reports");
+  const [isConsultantGoals] = useRoute("/consultant/clients-goals");
   const clientRouteMatch = /^\/consultant\/clients\/([^/]+)/.exec(location);
   const linkBase = clientRouteMatch ? clientRouteMatch[0] : "";
   const isInConsultantClientView = !!linkBase;
@@ -99,11 +97,9 @@ export function AppLayout({ children }: PropsWithChildren) {
   const [isGoals] = useRoute("/goals");
   const [isGoalsClient] = useRoute("/consultant/clients/:organizationId/goals");
   const isProfile = location.startsWith("/profile");
-  const consultantUser = isConsultant(user);
+  const consultantUser = useCanAccess('consultant');
   const [isNewTransactionOpen, setIsNewTransactionOpen] = useState(false);
   const { toast } = useToast();
-  
-  // Obter título dinâmico baseado na rota atual
   const pageTitle = getPageTitle(location);
 
   const handleLogout = () => {
@@ -171,78 +167,171 @@ export function AppLayout({ children }: PropsWithChildren) {
               <SidebarGroupLabel className="text-white/80">Navegação</SidebarGroupLabel>
               <SidebarGroupContent>
                 <SidebarMenu>
-                  {consultantUser && (
-                    <SidebarMenuItem>
-                      <Link href="/consultant">
-                        <SidebarMenuButton asChild isActive={!!isConsultantDashboard} className="hover:bg-white/10 data-[active=true]:bg-white">
-                          <a className="text-white data-[active=true]:!text-[#111827]">
-                            <Users />
-                            <span>Consultor</span>
-                          </a>
-                        </SidebarMenuButton>
-                      </Link>
-                    </SidebarMenuItem>
+                  {/* Área do Consultor - apenas para consultores */}
+                  {consultantUser ? (
+                    <>
+                      <SidebarMenuItem>
+                        <Link href="/consultant">
+                          <SidebarMenuButton asChild isActive={!!isConsultantDashboard} className="hover:bg-white/10 data-[active=true]:bg-white">
+                            <a className="text-white data-[active=true]:!text-[#111827]">
+                              <LayoutGrid />
+                              <span>Dashboard</span>
+                            </a>
+                          </SidebarMenuButton>
+                        </Link>
+                      </SidebarMenuItem>
+                      <SidebarMenuItem>
+                        <Link href="/consultant/clients">
+                          <SidebarMenuButton asChild isActive={!!isConsultantClients && !clientRouteMatch} className="hover:bg-white/10 data-[active=true]:bg-white">
+                            <a className="text-white data-[active=true]:!text-[#111827]">
+                              <Users />
+                              <span>Meus Clientes</span>
+                            </a>
+                          </SidebarMenuButton>
+                        </Link>
+                      </SidebarMenuItem>
+                      <SidebarMenuItem>
+                        <Link href="/consultant/reports">
+                          <SidebarMenuButton asChild isActive={!!isConsultantReports} className="hover:bg-white/10 data-[active=true]:bg-white">
+                            <a className="text-white data-[active=true]:!text-[#111827]">
+                              <PieChart />
+                              <span>Relatórios</span>
+                            </a>
+                          </SidebarMenuButton>
+                        </Link>
+                      </SidebarMenuItem>
+                      <SidebarMenuItem>
+                        <Link href="/consultant/clients-goals">
+                          <SidebarMenuButton asChild isActive={!!isConsultantGoals} className="hover:bg-white/10 data-[active=true]:bg-white">
+                            <a className="text-white data-[active=true]:!text-[#111827]">
+                              <Target />
+                              <span>Metas</span>
+                            </a>
+                          </SidebarMenuButton>
+                        </Link>
+                      </SidebarMenuItem>
+                      {isInConsultantClientView && (
+                        <>
+                          <SidebarSeparator className="bg-white/20 my-2" />
+                          <SidebarGroupLabel className="text-white/60 text-xs px-2">Cliente</SidebarGroupLabel>
+                          <SidebarMenuItem>
+                            <Link href={linkBase}>
+                              <SidebarMenuButton asChild isActive={!location.split("/").slice(4).filter(Boolean).length} className="hover:bg-white/10 data-[active=true]:bg-white">
+                                <a className="text-white data-[active=true]:!text-[#111827]">
+                                  <LayoutGrid />
+                                  <span>Dashboard</span>
+                                </a>
+                              </SidebarMenuButton>
+                            </Link>
+                          </SidebarMenuItem>
+                          <SidebarMenuItem>
+                            <Link href={`${linkBase}/transactions`}>
+                              <SidebarMenuButton asChild isActive={!!isTransactionsClient} className="hover:bg-white/10 data-[active=true]:bg-white">
+                                <a className="text-white data-[active=true]:!text-[#111827]">
+                                  <ListOrdered />
+                                  <span>Transações</span>
+                                </a>
+                              </SidebarMenuButton>
+                            </Link>
+                          </SidebarMenuItem>
+                          <SidebarMenuItem>
+                            <Link href={`${linkBase}/credit-cards`}>
+                              <SidebarMenuButton asChild isActive={!!isCreditCardsClient} className="hover:bg-white/10 data-[active=true]:bg-white">
+                                <a className="text-white data-[active=true]:!text-[#111827]">
+                                  <CreditCard />
+                                  <span>Cartões</span>
+                                </a>
+                              </SidebarMenuButton>
+                            </Link>
+                          </SidebarMenuItem>
+                          <SidebarMenuItem>
+                            <Link href={`${linkBase}/reports`}>
+                              <SidebarMenuButton asChild isActive={!!isReportsClient} className="hover:bg-white/10 data-[active=true]:bg-white">
+                                <a className="text-white data-[active=true]:!text-[#111827]">
+                                  <PieChart />
+                                  <span>Relatórios</span>
+                                </a>
+                              </SidebarMenuButton>
+                            </Link>
+                          </SidebarMenuItem>
+                          <SidebarMenuItem>
+                            <Link href={`${linkBase}/goals`}>
+                              <SidebarMenuButton asChild isActive={!!isGoalsClient} className="hover:bg-white/10 data-[active=true]:bg-white">
+                                <a className="text-white data-[active=true]:!text-[#111827]">
+                                  <Target />
+                                  <span>Metas</span>
+                                </a>
+                              </SidebarMenuButton>
+                            </Link>
+                          </SidebarMenuItem>
+                        </>
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      {/* Dashboard padrão - para usuários não-consultores */}
+                      <SidebarMenuItem>
+                        <Link href="/">
+                          <SidebarMenuButton asChild isActive={!!isDashboard} className="hover:bg-white/10 data-[active=true]:bg-white">
+                            <a className="text-white data-[active=true]:!text-[#111827]">
+                              <LayoutGrid />
+                              <span>Dashboard</span>
+                            </a>
+                          </SidebarMenuButton>
+                        </Link>
+                      </SidebarMenuItem>
+                      <SidebarMenuItem>
+                        <Link href="/transactions">
+                          <SidebarMenuButton asChild isActive={!!isTransactions} className="hover:bg-white/10 data-[active=true]:bg-white">
+                            <a className="text-white data-[active=true]:!text-[#111827]">
+                              <ListOrdered />
+                              <span>Transações</span>
+                            </a>
+                          </SidebarMenuButton>
+                        </Link>
+                      </SidebarMenuItem>
+                      <SidebarMenuItem>
+                        <Link href="/credit-cards">
+                          <SidebarMenuButton asChild isActive={!!isCreditCards} className="hover:bg-white/10 data-[active=true]:bg-white">
+                            <a className="text-white data-[active=true]:!text-[#111827]">
+                              <CreditCard />
+                              <span>Cartões</span>
+                            </a>
+                          </SidebarMenuButton>
+                        </Link>
+                      </SidebarMenuItem>
+                      <SidebarMenuItem>
+                        <Link href="/reports">
+                          <SidebarMenuButton asChild isActive={!!isReports} className="hover:bg-white/10 data-[active=true]:bg-white">
+                            <a className="text-white data-[active=true]:!text-[#111827]">
+                              <PieChart />
+                              <span>Relatórios</span>
+                            </a>
+                          </SidebarMenuButton>
+                        </Link>
+                      </SidebarMenuItem>
+                      <SidebarMenuItem>
+                        <Link href="/goals">
+                          <SidebarMenuButton asChild isActive={!!isGoals} className="hover:bg-white/10 data-[active=true]:bg-white">
+                            <a className="text-white data-[active=true]:!text-[#111827]">
+                              <Target />
+                              <span>Metas</span>
+                            </a>
+                          </SidebarMenuButton>
+                        </Link>
+                      </SidebarMenuItem>
+                      <SidebarMenuItem>
+                        <Link href="/profile/me">
+                          <SidebarMenuButton asChild isActive={!!isProfile} className="hover:bg-white/10 data-[active=true]:bg-white">
+                            <a className="text-white data-[active=true]:!text-[#111827]">
+                              <User />
+                              <span>Perfil</span>
+                            </a>
+                          </SidebarMenuButton>
+                        </Link>
+                      </SidebarMenuItem>
+                    </>
                   )}
-                  <SidebarMenuItem>
-                    <Link href={linkBase || (consultantUser ? "/consultant" : "/")}>
-                      <SidebarMenuButton asChild isActive={!!isDashboard || (isInConsultantClientView && !location.split("/").slice(4).filter(Boolean).length)} className="hover:bg-white/10 data-[active=true]:bg-white">
-                        <a className="text-white data-[active=true]:!text-[#111827]">
-                          <LayoutGrid />
-                          <span>Dashboard</span>
-                        </a>
-                      </SidebarMenuButton>
-                    </Link>
-                  </SidebarMenuItem>
-                  <SidebarMenuItem>
-                    <Link href={linkBase ? `${linkBase}/transactions` : "/transactions"}>
-                      <SidebarMenuButton asChild isActive={!!isTransactions || !!isTransactionsClient} className="hover:bg-white/10 data-[active=true]:bg-white">
-                        <a className="text-white data-[active=true]:!text-[#111827]" aria-current={isTransactions || isTransactionsClient ? 'page' : undefined}>
-                          <ListOrdered />
-                          <span>Transações</span>
-                        </a>
-                      </SidebarMenuButton>
-                    </Link>
-                  </SidebarMenuItem>
-                  <SidebarMenuItem>
-                    <Link href={linkBase ? `${linkBase}/credit-cards` : "/credit-cards"}>
-                      <SidebarMenuButton asChild isActive={!!isCreditCards || !!isCreditCardsClient} className="hover:bg-white/10 data-[active=true]:bg-white">
-                        <a className="text-white data-[active=true]:!text-[#111827]" aria-current={isCreditCards || isCreditCardsClient ? 'page' : undefined}>
-                          <CreditCard />
-                          <span>Cartões</span>
-                        </a>
-                      </SidebarMenuButton>
-                    </Link>
-                  </SidebarMenuItem>
-                  <SidebarMenuItem>
-                    <Link href={linkBase ? `${linkBase}/reports` : "/reports"}>
-                      <SidebarMenuButton asChild isActive={!!isReports || !!isReportsClient} className="hover:bg-white/10 data-[active=true]:bg-white">
-                        <a className="text-white data-[active=true]:!text-[#111827]" aria-current={isReports || isReportsClient ? 'page' : undefined}>
-                          <PieChart />
-                          <span>Relatórios</span>
-                        </a>
-                      </SidebarMenuButton>
-                    </Link>
-                  </SidebarMenuItem>
-                  <SidebarMenuItem>
-                    <Link href={linkBase ? `${linkBase}/goals` : "/goals"}>
-                      <SidebarMenuButton asChild isActive={!!isGoals || !!isGoalsClient} className="hover:bg-white/10 data-[active=true]:bg-white">
-                        <a className="text-white data-[active=true]:!text-[#111827]" aria-current={isGoals || isGoalsClient ? 'page' : undefined}>
-                          <Target />
-                          <span>Metas</span>
-                        </a>
-                      </SidebarMenuButton>
-                    </Link>
-                  </SidebarMenuItem>
-                  <SidebarMenuItem>
-                    <Link href="/profile/me">
-                      <SidebarMenuButton asChild isActive={!!isProfile} className="hover:bg-white/10 data-[active=true]:bg-white">
-                        <a className="text-white data-[active=true]:!text-[#111827]" aria-current={isProfile ? 'page' : undefined}>
-                          <User />
-                          <span>Perfil</span>
-                        </a>
-                      </SidebarMenuButton>
-                    </Link>
-                  </SidebarMenuItem>
                 </SidebarMenu>
               </SidebarGroupContent>
             </SidebarGroup>

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -206,7 +206,7 @@ export function AppLayout({ children }: PropsWithChildren) {
                   <SidebarMenuItem>
                     <Link href={linkBase ? `${linkBase}/credit-cards` : "/credit-cards"}>
                       <SidebarMenuButton asChild isActive={!!isCreditCards || !!isCreditCardsClient} className="hover:bg-white/10 data-[active=true]:bg-white">
-                        <a className="text-white data-[active=true]:!text-[#111827]" aria-current={isCreditCards ? 'page' : undefined}>
+                        <a className="text-white data-[active=true]:!text-[#111827]" aria-current={isCreditCards || isCreditCardsClient ? 'page' : undefined}>
                           <CreditCard />
                           <span>Cartões</span>
                         </a>
@@ -216,7 +216,7 @@ export function AppLayout({ children }: PropsWithChildren) {
                   <SidebarMenuItem>
                     <Link href={linkBase ? `${linkBase}/reports` : "/reports"}>
                       <SidebarMenuButton asChild isActive={!!isReports || !!isReportsClient} className="hover:bg-white/10 data-[active=true]:bg-white">
-                        <a className="text-white data-[active=true]:!text-[#111827]" aria-current={isReports ? 'page' : undefined}>
+                        <a className="text-white data-[active=true]:!text-[#111827]" aria-current={isReports || isReportsClient ? 'page' : undefined}>
                           <PieChart />
                           <span>Relatórios</span>
                         </a>
@@ -226,7 +226,7 @@ export function AppLayout({ children }: PropsWithChildren) {
                   <SidebarMenuItem>
                     <Link href={linkBase ? `${linkBase}/goals` : "/goals"}>
                       <SidebarMenuButton asChild isActive={!!isGoals || !!isGoalsClient} className="hover:bg-white/10 data-[active=true]:bg-white">
-                        <a className="text-white data-[active=true]:!text-[#111827]" aria-current={isGoals ? 'page' : undefined}>
+                        <a className="text-white data-[active=true]:!text-[#111827]" aria-current={isGoals || isGoalsClient ? 'page' : undefined}>
                           <Target />
                           <span>Metas</span>
                         </a>
@@ -288,8 +288,11 @@ export function AppLayout({ children }: PropsWithChildren) {
               </div>
               <div className="hidden md:flex flex-1 max-w-xl lg:max-w-2xl xl:max-w-3xl" />
               <div className="flex items-center gap-2 sm:gap-3 shrink-0">
-                {/* Organization Selector - Só mostrar quando há múltiplas organizações */}
-                {organizations.length > 1 && (
+                {consultantUser && location === '/consultant' ? (
+                  <span className="text-sm text-muted-foreground font-medium px-3 py-1.5 rounded-full bg-muted/60">
+                    Visão consolidada
+                  </span>
+                ) : organizations.length > 1 ? (
                   <Select value={activeOrgId || undefined} onValueChange={handleOrgChange}>
                     <SelectTrigger className="w-[140px] md:w-[180px] h-8 sm:h-9 rounded-full bg-white/70 ring-1 ring-gray-200 text-xs sm:text-sm">
                       <SelectValue placeholder="Selecionar organização" />
@@ -302,7 +305,7 @@ export function AppLayout({ children }: PropsWithChildren) {
                       ))}
                     </SelectContent>
                   </Select>
-                )}
+                ) : null}
 
                 {/* Menu de contexto do usuário */}
                 <DropdownMenu>

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/components/ui/sidebar";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { TrendingUp, LayoutGrid, ListOrdered, PieChart, Target, User, LogOut, Plus, CreditCard, Settings } from "lucide-react";
+import { TrendingUp, LayoutGrid, ListOrdered, PieChart, Target, User, LogOut, Plus, CreditCard, Settings, Users } from "lucide-react";
 import { PropsWithChildren, useState } from "react";
 // import { useAIChat } from "@/hooks/useAIChat"; // TODO: Reativar no futuro quando a feature estiver pronta
 // import { ChatBar } from "@/components/ChatBar"; // TODO: Reativar no futuro quando a feature estiver pronta
@@ -34,6 +34,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useAuth } from "@/hooks/useAuth";
 import { useOrganization } from "@/hooks/useOrganization";
+import { isConsultant } from "@/lib/consultant";
 import { NewTransactionSheet } from "@/components/NewTransactionSheet";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
@@ -55,6 +56,7 @@ const ROUTE_TITLES: Record<string, string> = {
   '/profile/categorias': 'Configurações',
   '/profile/assinatura': 'Configurações',
   '/profile/change-password': 'Alterar Senha',
+  '/consultant': 'Consultor',
 };
 
 /**
@@ -66,8 +68,13 @@ function getPageTitle(location: string): string {
   if (ROUTE_TITLES[location]) {
     return ROUTE_TITLES[location];
   }
-  
-  // Fallback: retornar 'Dashboard' se rota não encontrada
+  // Rotas de cliente do consultor
+  if (/^\/consultant\/clients\/[^/]+$/.test(location)) return 'Dashboard';
+  if (/^\/consultant\/clients\/[^/]+\/transactions/.test(location)) return 'Transações';
+  if (/^\/consultant\/clients\/[^/]+\/credit-cards/.test(location)) return 'Cartões';
+  if (/^\/consultant\/clients\/[^/]+\/reports/.test(location)) return 'Relatórios';
+  if (/^\/consultant\/clients\/[^/]+\/goals/.test(location)) return 'Metas';
+  // Fallback
   return 'Dashboard';
 }
 
@@ -78,11 +85,20 @@ export function AppLayout({ children }: PropsWithChildren) {
   const { organizations, activeOrgId, selectOrganization } = useOrganization();
   const [location, setLocation] = useLocation();
   const [isDashboard] = useRoute("/");
+  const [isConsultantDashboard] = useRoute("/consultant");
+  const clientRouteMatch = /^\/consultant\/clients\/([^/]+)/.exec(location);
+  const linkBase = clientRouteMatch ? clientRouteMatch[0] : "";
+  const isInConsultantClientView = !!linkBase;
   const [isTransactions] = useRoute("/transactions");
+  const [isTransactionsClient] = useRoute("/consultant/clients/:organizationId/transactions");
   const [isCreditCards] = useRoute("/credit-cards");
+  const [isCreditCardsClient] = useRoute("/consultant/clients/:organizationId/credit-cards");
   const [isReports] = useRoute("/reports");
+  const [isReportsClient] = useRoute("/consultant/clients/:organizationId/reports");
   const [isGoals] = useRoute("/goals");
+  const [isGoalsClient] = useRoute("/consultant/clients/:organizationId/goals");
   const isProfile = location.startsWith("/profile");
+  const consultantUser = isConsultant(user);
   const [isNewTransactionOpen, setIsNewTransactionOpen] = useState(false);
   const { toast } = useToast();
   
@@ -154,9 +170,21 @@ export function AppLayout({ children }: PropsWithChildren) {
               <SidebarGroupLabel className="text-white/80">Navegação</SidebarGroupLabel>
               <SidebarGroupContent>
                 <SidebarMenu>
+                  {consultantUser && (
+                    <SidebarMenuItem>
+                      <Link href="/consultant">
+                        <SidebarMenuButton asChild isActive={!!isConsultantDashboard} className="hover:bg-white/10 data-[active=true]:bg-white">
+                          <a className="text-white data-[active=true]:!text-[#111827]">
+                            <Users />
+                            <span>Consultor</span>
+                          </a>
+                        </SidebarMenuButton>
+                      </Link>
+                    </SidebarMenuItem>
+                  )}
                   <SidebarMenuItem>
-                    <Link href="/">
-                      <SidebarMenuButton asChild isActive={!!isDashboard} className="hover:bg-white/10 data-[active=true]:bg-white">
+                    <Link href={linkBase || (consultantUser ? "/consultant" : "/")}>
+                      <SidebarMenuButton asChild isActive={!!isDashboard || (isInConsultantClientView && !location.split("/").slice(4).filter(Boolean).length)} className="hover:bg-white/10 data-[active=true]:bg-white">
                         <a className="text-white data-[active=true]:!text-[#111827]">
                           <LayoutGrid />
                           <span>Dashboard</span>
@@ -165,9 +193,9 @@ export function AppLayout({ children }: PropsWithChildren) {
                     </Link>
                   </SidebarMenuItem>
                   <SidebarMenuItem>
-                    <Link href="/transactions">
-                      <SidebarMenuButton asChild isActive={!!isTransactions} className="hover:bg-white/10 data-[active=true]:bg-white">
-                        <a className="text-white data-[active=true]:!text-[#111827]" aria-current={isTransactions ? 'page' : undefined}>
+                    <Link href={linkBase ? `${linkBase}/transactions` : "/transactions"}>
+                      <SidebarMenuButton asChild isActive={!!isTransactions || !!isTransactionsClient} className="hover:bg-white/10 data-[active=true]:bg-white">
+                        <a className="text-white data-[active=true]:!text-[#111827]" aria-current={isTransactions || isTransactionsClient ? 'page' : undefined}>
                           <ListOrdered />
                           <span>Transações</span>
                         </a>
@@ -175,8 +203,8 @@ export function AppLayout({ children }: PropsWithChildren) {
                     </Link>
                   </SidebarMenuItem>
                   <SidebarMenuItem>
-                    <Link href="/credit-cards">
-                      <SidebarMenuButton asChild isActive={!!isCreditCards} className="hover:bg-white/10 data-[active=true]:bg-white">
+                    <Link href={linkBase ? `${linkBase}/credit-cards` : "/credit-cards"}>
+                      <SidebarMenuButton asChild isActive={!!isCreditCards || !!isCreditCardsClient} className="hover:bg-white/10 data-[active=true]:bg-white">
                         <a className="text-white data-[active=true]:!text-[#111827]" aria-current={isCreditCards ? 'page' : undefined}>
                           <CreditCard />
                           <span>Cartões</span>
@@ -185,8 +213,8 @@ export function AppLayout({ children }: PropsWithChildren) {
                     </Link>
                   </SidebarMenuItem>
                   <SidebarMenuItem>
-                    <Link href="/reports">
-                      <SidebarMenuButton asChild isActive={!!isReports} className="hover:bg-white/10 data-[active=true]:bg-white">
+                    <Link href={linkBase ? `${linkBase}/reports` : "/reports"}>
+                      <SidebarMenuButton asChild isActive={!!isReports || !!isReportsClient} className="hover:bg-white/10 data-[active=true]:bg-white">
                         <a className="text-white data-[active=true]:!text-[#111827]" aria-current={isReports ? 'page' : undefined}>
                           <PieChart />
                           <span>Relatórios</span>
@@ -195,8 +223,8 @@ export function AppLayout({ children }: PropsWithChildren) {
                     </Link>
                   </SidebarMenuItem>
                   <SidebarMenuItem>
-                    <Link href="/goals">
-                      <SidebarMenuButton asChild isActive={!!isGoals} className="hover:bg-white/10 data-[active=true]:bg-white">
+                    <Link href={linkBase ? `${linkBase}/goals` : "/goals"}>
+                      <SidebarMenuButton asChild isActive={!!isGoals || !!isGoalsClient} className="hover:bg-white/10 data-[active=true]:bg-white">
                         <a className="text-white data-[active=true]:!text-[#111827]" aria-current={isGoals ? 'page' : undefined}>
                           <Target />
                           <span>Metas</span>

--- a/src/layouts/ConsultantClientLayout.tsx
+++ b/src/layouts/ConsultantClientLayout.tsx
@@ -1,0 +1,10 @@
+import Dashboard from '@/pages/dashboard';
+
+/**
+ * Wrapper para a rota base do cliente do consultor.
+ * useOrganization já prioriza organizationId da URL, então o Dashboard funciona normalmente.
+ * Breadcrumb será adicionado em Task 7.
+ */
+export function ConsultantClientLayout() {
+  return <Dashboard />;
+}

--- a/src/layouts/ConsultantClientLayout.tsx
+++ b/src/layouts/ConsultantClientLayout.tsx
@@ -1,10 +1,5 @@
 import Dashboard from '@/pages/dashboard';
 
-/**
- * Wrapper para a rota base do cliente do consultor.
- * useOrganization já prioriza organizationId da URL, então o Dashboard funciona normalmente.
- * Breadcrumb será adicionado em Task 7.
- */
 export function ConsultantClientLayout() {
   return <Dashboard />;
 }

--- a/src/lib/__tests__/consultant.test.ts
+++ b/src/lib/__tests__/consultant.test.ts
@@ -51,4 +51,21 @@ describe('isConsultant', () => {
     };
     expect(isConsultant(user)).toBe(false);
   });
+
+  it('returns false for demo user even with consultant features', () => {
+    const user: User = {
+      id: '1',
+      email: 'demo@fincla.com.app',
+      role: 'owner',
+      created_at: '',
+      subscription: {
+        plan: 'premium',
+        status: 'active',
+        max_organizations: 10,
+        max_users_per_org: 5,
+        features: ['multi_org_dashboard'],
+      },
+    };
+    expect(isConsultant(user)).toBe(false);
+  });
 });

--- a/src/lib/__tests__/consultant.test.ts
+++ b/src/lib/__tests__/consultant.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { isConsultant } from '../consultant';
+import type { User } from '@/types/api';
+
+describe('isConsultant', () => {
+  it('returns false when user is null', () => {
+    expect(isConsultant(null)).toBe(false);
+  });
+
+  it('returns false when user has no subscription', () => {
+    expect(
+      isConsultant({
+        id: '1',
+        email: 'a@b.com',
+        role: 'owner',
+        created_at: '',
+      } as User)
+    ).toBe(false);
+  });
+
+  it('returns true when user has multi_org_dashboard', () => {
+    const user: User = {
+      id: '1',
+      email: 'a@b.com',
+      role: 'owner',
+      created_at: '',
+      subscription: {
+        plan: 'premium',
+        status: 'active',
+        max_organizations: 10,
+        max_users_per_org: 5,
+        features: ['multi_org_dashboard'],
+      },
+    };
+    expect(isConsultant(user)).toBe(true);
+  });
+
+  it('returns false when user has no consultant features', () => {
+    const user: User = {
+      id: '1',
+      email: 'a@b.com',
+      role: 'owner',
+      created_at: '',
+      subscription: {
+        plan: 'free',
+        status: 'active',
+        max_organizations: 1,
+        max_users_per_org: 1,
+        features: [],
+      },
+    };
+    expect(isConsultant(user)).toBe(false);
+  });
+});

--- a/src/lib/__tests__/consultant.test.ts
+++ b/src/lib/__tests__/consultant.test.ts
@@ -7,21 +7,36 @@ describe('isConsultant', () => {
     expect(isConsultant(null)).toBe(false);
   });
 
-  it('returns false when user has no subscription', () => {
-    expect(
-      isConsultant({
-        id: '1',
-        email: 'a@b.com',
-        role: 'owner',
-        created_at: '',
-      } as User)
-    ).toBe(false);
+  it('returns false when user is undefined', () => {
+    expect(isConsultant(undefined)).toBe(false);
   });
 
-  it('returns true when user has multi_org_dashboard', () => {
+  it('returns false when user has role owner', () => {
     const user: User = {
       id: '1',
-      email: 'a@b.com',
+      email: 'owner@example.com',
+      role: 'owner',
+      created_at: '',
+      subscription: { plan: 'free', status: 'active', max_organizations: 1, max_users_per_org: 1, features: [] },
+    };
+    expect(isConsultant(user)).toBe(false);
+  });
+
+  it('returns false when user has role member', () => {
+    const user: User = {
+      id: '1',
+      email: 'member@example.com',
+      role: 'member',
+      created_at: '',
+      subscription: { plan: 'free', status: 'active', max_organizations: 1, max_users_per_org: 1, features: [] },
+    };
+    expect(isConsultant(user)).toBe(false);
+  });
+
+  it('returns false when user has role owner even with consultant features', () => {
+    const user: User = {
+      id: '1',
+      email: 'demo@financeiro.app',
       role: 'owner',
       created_at: '',
       subscription: {
@@ -29,43 +44,26 @@ describe('isConsultant', () => {
         status: 'active',
         max_organizations: 10,
         max_users_per_org: 5,
-        features: ['multi_org_dashboard'],
+        features: ['client_list'],
       },
     };
-    expect(isConsultant(user)).toBe(true);
+    expect(isConsultant(user)).toBe(false);
   });
 
-  it('returns false when user has no consultant features', () => {
+  it('returns true only when user has role consultant', () => {
     const user: User = {
       id: '1',
-      email: 'a@b.com',
-      role: 'owner',
+      email: 'consultant@example.com',
+      role: 'consultant',
       created_at: '',
       subscription: {
-        plan: 'free',
+        plan: 'premium',
         status: 'active',
-        max_organizations: 1,
-        max_users_per_org: 1,
+        max_organizations: 10,
+        max_users_per_org: 5,
         features: [],
       },
     };
-    expect(isConsultant(user)).toBe(false);
-  });
-
-  it('returns false for demo user even with consultant features', () => {
-    const user: User = {
-      id: '1',
-      email: 'demo@fincla.com.app',
-      role: 'owner',
-      created_at: '',
-      subscription: {
-        plan: 'premium',
-        status: 'active',
-        max_organizations: 10,
-        max_users_per_org: 5,
-        features: ['multi_org_dashboard'],
-      },
-    };
-    expect(isConsultant(user)).toBe(false);
+    expect(isConsultant(user)).toBe(true);
   });
 });

--- a/src/lib/__tests__/permissions.test.ts
+++ b/src/lib/__tests__/permissions.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { canAccess, CONSULTANT_403_KEY } from '../permissions';
+import type { User } from '@/types/api';
+
+const consultantUser: User = {
+  id: '1',
+  email: 'consultant@example.com',
+  role: 'consultant',
+  first_name: 'Consultant',
+  last_name: 'User',
+  subscription: { features: [] },
+} as User;
+
+const memberUser: User = {
+  id: '2',
+  email: 'member@example.com',
+  role: 'member',
+  first_name: 'Member',
+  last_name: 'User',
+  subscription: { features: [] },
+} as User;
+
+describe('canAccess', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'sessionStorage',
+      {
+        getItem: vi.fn(),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+        length: 0,
+        key: vi.fn(),
+      } as Storage
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns false for null user', () => {
+    expect(canAccess('consultant', null)).toBe(false);
+  });
+
+  it('returns false for undefined user', () => {
+    expect(canAccess('consultant', undefined)).toBe(false);
+  });
+
+  it('returns false for non-consultant user', () => {
+    expect(canAccess('consultant', memberUser)).toBe(false);
+  });
+
+  it('returns true for consultant user when no 403 flag', () => {
+    vi.mocked(sessionStorage.getItem).mockReturnValue(null);
+    expect(canAccess('consultant', consultantUser)).toBe(true);
+  });
+
+  it('returns false for consultant user when consultant_403 flag is set', () => {
+    vi.mocked(sessionStorage.getItem).mockImplementation((key) =>
+      key === CONSULTANT_403_KEY ? '1' : null
+    );
+    expect(canAccess('consultant', consultantUser)).toBe(false);
+  });
+});

--- a/src/lib/consultant.ts
+++ b/src/lib/consultant.ts
@@ -1,0 +1,14 @@
+import type { User } from '@/types/api';
+
+const CONSULTANT_FEATURES = [
+  'multi_org_dashboard',
+  'client_list',
+  'consolidated_reports',
+] as const;
+
+export function isConsultant(user: User | null | undefined): boolean {
+  if (!user?.subscription?.features?.length) return false;
+  return CONSULTANT_FEATURES.some((f) =>
+    user.subscription!.features!.includes(f)
+  );
+}

--- a/src/lib/consultant.ts
+++ b/src/lib/consultant.ts
@@ -1,20 +1,6 @@
 import type { User } from '@/types/api';
 
-const CONSULTANT_FEATURES = [
-  'multi_org_dashboard',
-  'client_list',
-  'consolidated_reports',
-] as const;
-
-const NON_CONSULTANT_EMAILS = ['demo@fincla.com.app'];
-
 export function isConsultant(user: User | null | undefined): boolean {
-  if (!user?.subscription?.features?.length) return false;
-  const email = user.email?.toLowerCase().trim();
-  if (email && NON_CONSULTANT_EMAILS.some((e) => e.toLowerCase() === email)) {
-    return false;
-  }
-  return CONSULTANT_FEATURES.some((f) =>
-    user.subscription!.features!.includes(f)
-  );
+  if (!user) return false;
+  return user.role === 'consultant';
 }

--- a/src/lib/consultant.ts
+++ b/src/lib/consultant.ts
@@ -6,8 +6,14 @@ const CONSULTANT_FEATURES = [
   'consolidated_reports',
 ] as const;
 
+const NON_CONSULTANT_EMAILS = ['demo@fincla.com.app'];
+
 export function isConsultant(user: User | null | undefined): boolean {
   if (!user?.subscription?.features?.length) return false;
+  const email = user.email?.toLowerCase().trim();
+  if (email && NON_CONSULTANT_EMAILS.some((e) => e.toLowerCase() === email)) {
+    return false;
+  }
   return CONSULTANT_FEATURES.some((f) =>
     user.subscription!.features!.includes(f)
   );

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,0 +1,26 @@
+import type { User } from '@/types/api';
+import { isConsultant } from '@/lib/consultant';
+
+export const CONSULTANT_403_KEY = 'consultant_403';
+
+export type Permission = 'consultant';
+
+const PERMISSION_CHECKS: Record<
+  Permission,
+  (user: User | null | undefined) => boolean
+> = {
+  consultant: (user) => {
+    if (!isConsultant(user)) return false;
+    if (sessionStorage.getItem(CONSULTANT_403_KEY)) return false;
+    return true;
+  },
+};
+
+export function canAccess(
+  permission: Permission,
+  user: User | null | undefined
+): boolean {
+  const check = PERMISSION_CHECKS[permission];
+  if (!check) return false;
+  return check(user);
+}

--- a/src/pages/consultant/clients.tsx
+++ b/src/pages/consultant/clients.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'wouter';
+import { isAxiosError } from 'axios';
+import { useConsultantClients } from '@/hooks/useConsultantData';
+import { ConsultantClientList } from '@/components/consultant/ConsultantClientList';
+import { PageTransition } from '@/components/PageTransition';
+import { useToast } from '@/hooks/use-toast';
+import { CONSULTANT_403_KEY } from '@/lib/permissions';
+import { handleApiError } from '@/api/client';
+
+export default function ConsultantClientsPage() {
+  const [, setLocation] = useLocation();
+  const { toast } = useToast();
+  const errorHandledRef = useRef(false);
+
+  const { data: clientsData, isLoading, error } = useConsultantClients();
+  const clients = clientsData?.clients ?? [];
+
+  useEffect(() => {
+    if (!error) {
+      errorHandledRef.current = false;
+      return;
+    }
+    if (errorHandledRef.current) return;
+    errorHandledRef.current = true;
+    const status = isAxiosError(error) ? error.response?.status : null;
+    if (status === 403) {
+      sessionStorage.setItem(CONSULTANT_403_KEY, '1');
+      toast({
+        title: 'Acesso negado',
+        description: 'Você não tem permissão para acessar a área do consultor.',
+        variant: 'destructive',
+      });
+      setLocation('/');
+    } else {
+      toast({
+        title: 'Erro ao carregar clientes',
+        description: handleApiError(error),
+        variant: 'destructive',
+      });
+    }
+  }, [error, toast, setLocation]);
+
+  return (
+    <PageTransition>
+      <div className="mx-auto px-4 sm:px-6 lg:px-8 xl:px-10 max-w-7xl xl:max-w-[95%] 2xl:max-w-[1800px]">
+        <div className="mb-6">
+          <h1 className="text-2xl font-semibold tracking-tight">Meus Clientes</h1>
+          <p className="text-muted-foreground mt-1">
+            Gerencie e acompanhe os clientes vinculados à sua conta.
+          </p>
+        </div>
+        <ConsultantClientList clients={clients} isLoading={isLoading} />
+      </div>
+    </PageTransition>
+  );
+}

--- a/src/pages/consultant/index.tsx
+++ b/src/pages/consultant/index.tsx
@@ -1,0 +1,46 @@
+import { useDateRange } from '@/hooks/useDateRange';
+import { useConsultantSummary, useConsultantClients } from '@/hooks/useConsultantData';
+import { DateRangePicker } from '@/components/DateRangePicker';
+import { ConsultantSummaryCards } from '@/components/consultant/ConsultantSummaryCards';
+import { ConsultantClientList } from '@/components/consultant/ConsultantClientList';
+import { PageTransition } from '@/components/PageTransition';
+import { format } from 'date-fns';
+
+export default function ConsultantDashboard() {
+  const { dateRange, setDateRange: setDateRangeFromHook } = useDateRange('thisMonth');
+
+  const handleDateRangeChange = (range: { from: Date; to: Date } | undefined) => {
+    setDateRangeFromHook(range);
+  };
+
+  const params = dateRange
+    ? {
+        date_start: format(dateRange.from, 'yyyy-MM-dd'),
+        date_end: format(dateRange.to, 'yyyy-MM-dd'),
+      }
+    : undefined;
+
+  const { data: summary, isLoading: summaryLoading } = useConsultantSummary(params);
+  const { data: clientsData, isLoading: clientsLoading } = useConsultantClients();
+
+  const clients = clientsData?.clients ?? [];
+
+  return (
+    <PageTransition>
+      <div className="mx-auto px-4 sm:px-6 lg:px-8 xl:px-10 max-w-7xl xl:max-w-[95%] 2xl:max-w-[1800px]">
+        {/* Seletor de Período */}
+        <div className="mb-6 flex justify-end">
+          <DateRangePicker value={dateRange} onChange={handleDateRangeChange} />
+        </div>
+
+        {/* Cards de Resumo Consolidado */}
+        <ConsultantSummaryCards summary={summary} isLoading={summaryLoading} />
+
+        {/* Lista de Clientes */}
+        <div className="mt-8">
+          <ConsultantClientList clients={clients} isLoading={clientsLoading} />
+        </div>
+      </div>
+    </PageTransition>
+  );
+}

--- a/src/pages/consultant/index.tsx
+++ b/src/pages/consultant/index.tsx
@@ -43,7 +43,7 @@ export default function ConsultantDashboard() {
         variant: 'destructive',
       });
       setLocation('/');
-    } else if (err) {
+    } else {
       toast({
         title: 'Erro ao carregar dados',
         description: handleApiError(err),
@@ -55,15 +55,12 @@ export default function ConsultantDashboard() {
   return (
     <PageTransition>
       <div className="mx-auto px-4 sm:px-6 lg:px-8 xl:px-10 max-w-7xl xl:max-w-[95%] 2xl:max-w-[1800px]">
-        {/* Seletor de Período */}
         <div className="mb-6 flex justify-end">
           <DateRangePicker value={dateRange} onChange={handleDateRangeChange} />
         </div>
 
-        {/* Cards de Resumo Consolidado */}
         <ConsultantSummaryCards summary={summary} isLoading={summaryLoading} />
 
-        {/* Lista de Clientes */}
         <div className="mt-8">
           <ConsultantClientList clients={clients} isLoading={clientsLoading} />
         </div>

--- a/src/pages/consultant/index.tsx
+++ b/src/pages/consultant/index.tsx
@@ -1,55 +1,79 @@
-import { useEffect, useRef } from 'react';
-import { Redirect, useLocation } from 'wouter';
-import { useDateRange } from '@/hooks/useDateRange';
-import { useConsultantSummary, useConsultantClients } from '@/hooks/useConsultantData';
-import { DateRangePicker } from '@/components/DateRangePicker';
-import { ConsultantSummaryCards } from '@/components/consultant/ConsultantSummaryCards';
-import { ConsultantClientList } from '@/components/consultant/ConsultantClientList';
-import { PageTransition } from '@/components/PageTransition';
-import { useToast } from '@/hooks/use-toast';
-import { useAuth } from '@/hooks/useAuth';
-import { isConsultant } from '@/lib/consultant';
-import { handleApiError } from '@/api/client';
+import { useEffect, useRef, useState } from 'react';
+import { useLocation } from 'wouter';
+import { DateRange } from 'react-day-picker';
 import { format } from 'date-fns';
 import { isAxiosError } from 'axios';
+import {
+  useConsultantSummary,
+  useFinancialHealthIndex,
+  useActiveGoalsCount,
+  useTotalCreditCardDebt,
+  useCashFlow,
+  useExpensesByCategory,
+  useGoalsProgressByType,
+  useClientsAtRisk,
+} from '@/hooks/useConsultantData';
+import { ConsultantKPICards } from '@/components/consultant/ConsultantKPICards';
+import { ConsultantDateControls } from '@/components/consultant/ConsultantDateControls';
+import { ClientsAtRiskList } from '@/components/consultant/ClientsAtRiskList';
+import { CashFlowChart } from '@/components/consultant/CashFlowChart';
+import { ExpensesByCategoryChart } from '@/components/consultant/ExpensesByCategoryChart';
+import { GoalsProgressChart } from '@/components/consultant/GoalsProgressChart';
+import { PageTransition } from '@/components/PageTransition';
+import { useToast } from '@/hooks/use-toast';
+import { CONSULTANT_403_KEY } from '@/lib/permissions';
+import { handleApiError } from '@/api/client';
 
 export default function ConsultantDashboard() {
   const [, setLocation] = useLocation();
-  const { user } = useAuth();
   const { toast } = useToast();
   const errorHandledRef = useRef(false);
-  const { dateRange, setDateRange: setDateRangeFromHook } = useDateRange('thisMonth');
 
-  const handleDateRangeChange = (range: { from: Date; to: Date } | undefined) => {
-    setDateRangeFromHook(range);
-  };
+  // State for date controls
+  const [dateRange, setDateRange] = useState<DateRange | undefined>(() => {
+    const today = new Date();
+    const firstDayOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+    return { from: firstDayOfMonth, to: today };
+  });
+  const [snapshotDate, setSnapshotDate] = useState<Date | undefined>(new Date());
 
-  const params = dateRange
+  // Build query params for period-based endpoints (date_start, date_end)
+  const periodParams = dateRange?.from
     ? {
         date_start: format(dateRange.from, 'yyyy-MM-dd'),
-        date_end: format(dateRange.to, 'yyyy-MM-dd'),
+        date_end: dateRange.to ? format(dateRange.to, 'yyyy-MM-dd') : format(dateRange.from, 'yyyy-MM-dd'),
       }
     : undefined;
 
-  const { data: summary, isLoading: summaryLoading, error: summaryError } = useConsultantSummary(params);
-  const { data: clientsData, isLoading: clientsLoading, error: clientsError } = useConsultantClients();
+  // Build query params for snapshot-based endpoints (as_of_date)
+  const snapshotParam = snapshotDate
+    ? { as_of_date: format(snapshotDate, 'yyyy-MM-dd') }
+    : undefined;
 
-  const clients = clientsData?.clients ?? [];
-
-  if (!isConsultant(user)) {
-    return <Redirect to="/" />;
-  }
+  // Fetch all consultant data
+  const { data: summary, isLoading: summaryLoading, error: summaryError } = useConsultantSummary(periodParams);
+  const { data: healthIndex, isLoading: healthLoading } = useFinancialHealthIndex(periodParams);
+  const { data: creditCardDebt, isLoading: debtLoading } = useTotalCreditCardDebt(snapshotParam);
+  const { data: activeGoals, isLoading: goalsLoading } = useActiveGoalsCount(snapshotParam);
+  const { data: cashFlowData, isLoading: cashFlowLoading } = useCashFlow(periodParams);
+  const { data: expensesData, isLoading: expensesLoading } = useExpensesByCategory(periodParams);
+  const { data: goalsProgress, isLoading: goalsProgressLoading } = useGoalsProgressByType(snapshotParam);
+  const { data: clientsAtRisk, isLoading: atRiskLoading } = useClientsAtRisk({ ...snapshotParam, limit: 10 });
+  
+  const isLoading = summaryLoading || healthLoading || debtLoading || goalsLoading || 
+    cashFlowLoading || expensesLoading || goalsProgressLoading || atRiskLoading;
 
   useEffect(() => {
-    if (!summaryError && !clientsError) {
+    if (!summaryError) {
       errorHandledRef.current = false;
       return;
     }
     if (errorHandledRef.current) return;
     errorHandledRef.current = true;
-    const err = summaryError || clientsError;
+    const err = summaryError;
     const status = isAxiosError(err) ? err.response?.status : null;
     if (status === 403) {
+      sessionStorage.setItem(CONSULTANT_403_KEY, '1');
       toast({
         title: 'Acesso negado',
         description: 'Você não tem permissão para acessar a área do consultor.',
@@ -63,20 +87,41 @@ export default function ConsultantDashboard() {
         variant: 'destructive',
       });
     }
-  }, [summaryError, clientsError, toast, setLocation]);
+  }, [summaryError, toast, setLocation]);
 
   return (
     <PageTransition>
       <div className="mx-auto px-4 sm:px-6 lg:px-8 xl:px-10 max-w-7xl xl:max-w-[95%] 2xl:max-w-[1800px]">
-        <div className="mb-6 flex justify-end">
-          <DateRangePicker value={dateRange} onChange={handleDateRangeChange} />
+        {/* Date Controls */}
+        <div className="mb-6">
+          <ConsultantDateControls
+            dateRange={dateRange}
+            snapshotDate={snapshotDate}
+            onDateRangeChange={setDateRange}
+            onSnapshotDateChange={setSnapshotDate}
+          />
         </div>
 
-        <ConsultantSummaryCards summary={summary} isLoading={summaryLoading} />
+        {/* KPI Cards */}
+        <ConsultantKPICards
+          summary={summary}
+          healthIndex={healthIndex}
+          creditCardDebt={creditCardDebt}
+          activeGoals={activeGoals}
+          isLoading={isLoading}
+        />
 
-        <div className="mt-8">
-          <ConsultantClientList clients={clients} isLoading={clientsLoading} />
+        {/* Charts Row */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-8">
+          <CashFlowChart data={cashFlowData} isLoading={cashFlowLoading} />
+          <ExpensesByCategoryChart data={expensesData} isLoading={expensesLoading} />
         </div>
+
+        {/* Goals Progress */}
+        <GoalsProgressChart data={goalsProgress} isLoading={goalsProgressLoading} />
+
+        {/* Clients at Risk */}
+        <ClientsAtRiskList data={clientsAtRisk} isLoading={atRiskLoading} />
       </div>
     </PageTransition>
   );

--- a/src/pages/consultant/index.tsx
+++ b/src/pages/consultant/index.tsx
@@ -1,12 +1,19 @@
+import { useEffect } from 'react';
+import { useLocation } from 'wouter';
 import { useDateRange } from '@/hooks/useDateRange';
 import { useConsultantSummary, useConsultantClients } from '@/hooks/useConsultantData';
 import { DateRangePicker } from '@/components/DateRangePicker';
 import { ConsultantSummaryCards } from '@/components/consultant/ConsultantSummaryCards';
 import { ConsultantClientList } from '@/components/consultant/ConsultantClientList';
 import { PageTransition } from '@/components/PageTransition';
+import { useToast } from '@/hooks/use-toast';
+import { handleApiError } from '@/api/client';
 import { format } from 'date-fns';
+import { isAxiosError } from 'axios';
 
 export default function ConsultantDashboard() {
+  const [, setLocation] = useLocation();
+  const { toast } = useToast();
   const { dateRange, setDateRange: setDateRangeFromHook } = useDateRange('thisMonth');
 
   const handleDateRangeChange = (range: { from: Date; to: Date } | undefined) => {
@@ -20,10 +27,30 @@ export default function ConsultantDashboard() {
       }
     : undefined;
 
-  const { data: summary, isLoading: summaryLoading } = useConsultantSummary(params);
-  const { data: clientsData, isLoading: clientsLoading } = useConsultantClients();
+  const { data: summary, isLoading: summaryLoading, error: summaryError } = useConsultantSummary(params);
+  const { data: clientsData, isLoading: clientsLoading, error: clientsError } = useConsultantClients();
 
   const clients = clientsData?.clients ?? [];
+
+  useEffect(() => {
+    const err = summaryError || clientsError;
+    if (!err) return;
+    const status = isAxiosError(err) ? err.response?.status : null;
+    if (status === 403) {
+      toast({
+        title: 'Acesso negado',
+        description: 'Você não tem permissão para acessar a área do consultor.',
+        variant: 'destructive',
+      });
+      setLocation('/');
+    } else if (err) {
+      toast({
+        title: 'Erro ao carregar dados',
+        description: handleApiError(err),
+        variant: 'destructive',
+      });
+    }
+  }, [summaryError, clientsError, toast, setLocation]);
 
   return (
     <PageTransition>

--- a/src/pages/consultant/index.tsx
+++ b/src/pages/consultant/index.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useLocation } from 'wouter';
+import { useEffect, useRef } from 'react';
+import { Redirect, useLocation } from 'wouter';
 import { useDateRange } from '@/hooks/useDateRange';
 import { useConsultantSummary, useConsultantClients } from '@/hooks/useConsultantData';
 import { DateRangePicker } from '@/components/DateRangePicker';
@@ -7,13 +7,17 @@ import { ConsultantSummaryCards } from '@/components/consultant/ConsultantSummar
 import { ConsultantClientList } from '@/components/consultant/ConsultantClientList';
 import { PageTransition } from '@/components/PageTransition';
 import { useToast } from '@/hooks/use-toast';
+import { useAuth } from '@/hooks/useAuth';
+import { isConsultant } from '@/lib/consultant';
 import { handleApiError } from '@/api/client';
 import { format } from 'date-fns';
 import { isAxiosError } from 'axios';
 
 export default function ConsultantDashboard() {
   const [, setLocation] = useLocation();
+  const { user } = useAuth();
   const { toast } = useToast();
+  const errorHandledRef = useRef(false);
   const { dateRange, setDateRange: setDateRangeFromHook } = useDateRange('thisMonth');
 
   const handleDateRangeChange = (range: { from: Date; to: Date } | undefined) => {
@@ -32,9 +36,18 @@ export default function ConsultantDashboard() {
 
   const clients = clientsData?.clients ?? [];
 
+  if (!isConsultant(user)) {
+    return <Redirect to="/" />;
+  }
+
   useEffect(() => {
+    if (!summaryError && !clientsError) {
+      errorHandledRef.current = false;
+      return;
+    }
+    if (errorHandledRef.current) return;
+    errorHandledRef.current = true;
     const err = summaryError || clientsError;
-    if (!err) return;
     const status = isAxiosError(err) ? err.response?.status : null;
     if (status === 403) {
       toast({

--- a/src/pages/profile/ProfileMeSection.tsx
+++ b/src/pages/profile/ProfileMeSection.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from '@/hooks/useAuth';
+import { isConsultant } from '@/lib/consultant';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -49,7 +50,7 @@ export default function ProfileMeSection() {
             <div className="mt-4 flex flex-wrap gap-x-6 gap-y-2 text-sm">
               <span className="flex items-center gap-2 text-gray-800 dark:text-gray-200">
                 <Shield className="w-4 h-4 text-gray-600 dark:text-gray-400" />
-                {user?.role === 'owner' ? 'Administrador' : 'Membro'}
+                {isConsultant(user) ? 'Consultor' : user?.role === 'owner' ? 'Administrador' : 'Membro'}
               </span>
               <span className="flex items-center gap-2 text-gray-800 dark:text-gray-200">
                 <CalendarIcon className="w-4 h-4 text-gray-600 dark:text-gray-400" />

--- a/src/pages/transactions.tsx
+++ b/src/pages/transactions.tsx
@@ -1,12 +1,12 @@
 import { useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { listTransactions, deleteTransaction, getTransaction, getTransactionsSummary } from '@/api/transactions';
-import { Transaction } from '@/types/api';
+import { Transaction, InstallmentInfo } from '@/types/api';
 import { Card } from '@/components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { ArrowLeft, Download, Edit, Trash2, ArrowUpDown, ArrowUp, ArrowDown, TrendingUp, TrendingDown, Receipt } from 'lucide-react';
+import { ArrowLeft, Download, Edit, Trash2, ArrowUpDown, ArrowUp, ArrowDown, TrendingUp, TrendingDown, Receipt, CreditCard, Calendar } from 'lucide-react';
 import { Link, useLocation } from 'wouter';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -37,6 +37,118 @@ function formatDate(value: string | Date) {
     hour: '2-digit',
     minute: '2-digit'
   });
+}
+
+function formatDateShort(value: string | Date) {
+  const date = value instanceof Date ? value : new Date(value);
+  return format(date, 'dd/MM/yyyy', { locale: ptBR });
+}
+
+interface TransactionTableRow {
+  transactionId: number;
+  organizationId: string;
+  description: string;
+  category: string;
+  displayDate: string;
+  sortDate: string; // ISO ou YYYY-MM-DD para ordenação
+  displayPaymentMethod: string;
+  displayValue: number;
+  type: 'income' | 'expense';
+  transaction: Transaction;
+  installment?: InstallmentInfo;
+}
+
+function getCategory(tx: Transaction): string {
+  if (tx.category) return tx.category;
+  const tags = tx.tags as Record<string, { name: string }[]> | undefined;
+  return tags?.categoria?.[0]?.name ?? '-';
+}
+
+function mapPaymentMethodForDisplay(method: string): string {
+  const map: Record<string, string> = {
+    pix: 'PIX',
+    debit_card: 'Cartão de Débito',
+    credit_card: 'Cartão à vista',
+    bank_transfer: 'Transferência Bancária',
+    money: 'Dinheiro',
+    boleto: 'Boleto',
+  };
+  return map[method?.toLowerCase()] ?? method ?? '';
+}
+
+type TransactionWithAmount = Omit<Transaction, 'id' | 'date'> & {
+  id?: number | string;
+  originalId?: number;
+  date?: Date | string;
+  amount?: number;
+  installment_info?: InstallmentInfo[] | null;
+};
+function expandTransactionsToRows(transactions: TransactionWithAmount[]): TransactionTableRow[] {
+  const rows: TransactionTableRow[] = [];
+
+  for (const tx of transactions) {
+    const txId = (tx as { originalId?: number }).originalId ?? (typeof tx.id === 'number' ? tx.id : parseInt(String(tx.id), 10));
+    const category = getCategory(tx as Transaction);
+    const rawTx = { ...tx, id: txId } as Transaction;
+
+    // À vista: modality === 'cash' ou total_installments === 1 (fallback)
+    const modality = tx.credit_card_charge?.charge?.modality ?? (tx as { modality?: string }).modality;
+    const instList = tx.installment_info;
+    const firstInst = Array.isArray(instList) && instList.length > 0 ? instList[0] : null;
+    const isCash = modality === 'cash' || (firstInst?.total_installments === 1);
+    const shouldExpand = tx.installment_info?.length && !isCash;
+
+    if (shouldExpand) {
+      const instInfo = tx.installment_info ?? [];
+      const sorted = [...instInfo].sort((a, b) => a.due_date.localeCompare(b.due_date));
+      for (const inst of sorted) {
+        const displayValue = tx.type === 'income' ? inst.amount : -inst.amount;
+        rows.push({
+          transactionId: txId,
+          organizationId: tx.organization_id,
+          description: tx.description,
+          category,
+          displayDate: formatDateShort(inst.due_date),
+          sortDate: inst.due_date,
+          displayPaymentMethod: `Cartão parcelado (${inst.installment_number}/${inst.total_installments})`,
+          displayValue,
+          type: tx.type,
+          transaction: rawTx,
+          installment: inst,
+        });
+      }
+    } else {
+      const amount = tx.amount ?? (tx.type === 'income' ? tx.value : -tx.value);
+      const displayDate = formatDate(tx.date ?? new Date().toISOString());
+      const displayPaymentMethod = mapPaymentMethodForDisplay(tx.payment_method || '');
+      const cardLast4 = (tx as { card_last4?: string }).card_last4 ?? tx.credit_card_charge?.card?.last4;
+      const modality = (tx as { modality?: string }).modality ?? tx.credit_card_charge?.charge?.modality;
+      const installmentsCount = (tx as { installments_count?: number }).installments_count ?? tx.credit_card_charge?.charge?.installments_count;
+      const isCreditCard = tx.payment_method === 'credit_card' || tx.payment_method === 'Cartão de Crédito';
+      const finalPaymentMethod = isCreditCard && cardLast4
+        ? (modality === 'installment' && installmentsCount && installmentsCount > 1
+          ? `Cartão ${cardLast4} em ${installmentsCount}x`
+          : `Cartão ${cardLast4} à vista`)
+        : displayPaymentMethod || tx.payment_method || '';
+
+      const dateVal = tx.date as unknown;
+      const dateForSort = dateVal instanceof Date ? dateVal.toISOString() : String(tx.date);
+      rows.push({
+        transactionId: txId,
+        organizationId: tx.organization_id,
+        description: tx.description,
+        category,
+        displayDate,
+        sortDate: dateForSort,
+        displayPaymentMethod: finalPaymentMethod,
+        displayValue: amount,
+        type: tx.type,
+        transaction: rawTx,
+      });
+    }
+  }
+
+  return rows;
 }
 
 type SortField = 'description' | 'category' | 'date' | 'value' | 'payment_method';
@@ -233,53 +345,53 @@ export default function TransactionsPage() {
 
   const filtered = useMemo(() => {
     // A API já aplica todos os filtros; aplicar filtro de recorrência no cliente como fallback
-    // (caso a API não suporte o parâmetro recurring)
     let list = [...transactionsWithAmount];
     if (recurring === 'recurring') {
       list = list.filter((t) => (t as { recurring?: boolean }).recurring === true);
     } else if (recurring === 'non_recurring') {
       list = list.filter((t) => (t as { recurring?: boolean }).recurring !== true);
     }
-
-    // Ordenamento
-    if (sortField && sortDirection) {
-      list.sort((a, b) => {
-        let aVal: any;
-        let bVal: any;
-        
-        switch (sortField) {
-          case 'description':
-            aVal = a.description.toLowerCase();
-            bVal = b.description.toLowerCase();
-            break;
-          case 'category':
-            aVal = a.category.toLowerCase();
-            bVal = b.category.toLowerCase();
-            break;
-          case 'date':
-            aVal = a.date.getTime();
-            bVal = b.date.getTime();
-            break;
-          case 'value':
-            aVal = Math.abs(a.amount);
-            bVal = Math.abs(b.amount);
-            break;
-          case 'payment_method':
-            aVal = (a.payment_method || '').toLowerCase();
-            bVal = (b.payment_method || '').toLowerCase();
-            break;
-          default:
-            return 0;
-        }
-        
-        if (aVal < bVal) return sortDirection === 'asc' ? -1 : 1;
-        if (aVal > bVal) return sortDirection === 'asc' ? 1 : -1;
-        return 0;
-      });
-    }
-    
     return list;
-  }, [transactionsWithAmount, recurring, sortField, sortDirection]);
+  }, [transactionsWithAmount, recurring]);
+
+  // Expandir transações com installment_info em linhas (uma por parcela)
+  const expandedRows = useMemo(() => expandTransactionsToRows(filtered), [filtered]);
+
+  // Ordenar linhas expandidas (a API já ordena transações; parcelas já vêm ordenadas por due_date)
+  const sortedRows = useMemo(() => {
+    if (!sortField || !sortDirection) return expandedRows;
+    return [...expandedRows].sort((a, b) => {
+      let aVal: string | number;
+      let bVal: string | number;
+      switch (sortField) {
+        case 'description':
+          aVal = a.description.toLowerCase();
+          bVal = b.description.toLowerCase();
+          break;
+        case 'category':
+          aVal = a.category.toLowerCase();
+          bVal = b.category.toLowerCase();
+          break;
+        case 'date':
+          aVal = new Date(a.sortDate).getTime();
+          bVal = new Date(b.sortDate).getTime();
+          break;
+        case 'value':
+          aVal = Math.abs(a.displayValue);
+          bVal = Math.abs(b.displayValue);
+          break;
+        case 'payment_method':
+          aVal = a.displayPaymentMethod.toLowerCase();
+          bVal = b.displayPaymentMethod.toLowerCase();
+          break;
+        default:
+          return 0;
+      }
+      if (aVal < bVal) return sortDirection === 'asc' ? -1 : 1;
+      if (aVal > bVal) return sortDirection === 'asc' ? 1 : -1;
+      return 0;
+    });
+  }, [expandedRows, sortField, sortDirection]);
 
   // Estatísticas do período filtrado - usar dados do summary da API
   const stats = useMemo(() => {
@@ -293,37 +405,30 @@ export default function TransactionsPage() {
       };
     }
     
-    // Fallback: calcular do filtered se summary não estiver disponível
-    const total = filtered.length;
+    // Fallback: calcular das linhas expandidas
     let totalValue = 0;
     let income = 0;
     let expenses = 0;
-    
-    filtered.forEach((t) => {
-      const amount = typeof t.amount === 'number' ? t.amount : parseFloat(String(t.amount)) || 0;
+    sortedRows.forEach((row) => {
+      const amount = row.displayValue;
       const absAmount = Math.abs(amount);
-      
       totalValue += absAmount;
-      
-      if (amount > 0) {
-        income += amount;
-      } else if (amount < 0) {
-        expenses += absAmount;
-      }
+      if (amount > 0) income += amount;
+      else if (amount < 0) expenses += absAmount;
     });
-    
-    const balance = income - expenses;
-    
-    return { total, totalValue, income, expenses, balance };
-  }, [summaryData, filtered]);
+    return {
+      total: sortedRows.length,
+      totalValue,
+      income,
+      expenses,
+      balance: income - expenses,
+    };
+  }, [summaryData, sortedRows]);
 
   // Paginação - usar dados da API
   const pagination = transactionsData?.pagination;
   const totalPages = pagination?.pages || 1;
-  const paginatedTransactions = useMemo(() => {
-    // A API já retorna os dados paginados, então usamos diretamente
-    return filtered;
-  }, [filtered]);
+  const paginatedTransactions = useMemo(() => sortedRows, [sortedRows]);
 
   // Resetar página quando filtros mudarem
   useEffect(() => {
@@ -359,46 +464,14 @@ export default function TransactionsPage() {
     return <ArrowUpDown className="h-4 w-4 ml-1 opacity-50" />;
   };
 
-  const formatPaymentMethod = (transaction: any) => {
-    const method = transaction.payment_method || '';
-    const isCreditCard = method === 'Cartão de Crédito' || method === 'credit_card';
-    
-    if (!isCreditCard) {
-      return method;
-    }
-    
-    const cardLast4 = transaction.card_last4 || transaction.credit_card_charge?.card?.last4 || '';
-    const modality = transaction.modality || transaction.credit_card_charge?.charge?.modality;
-    const installmentsCount = transaction.installments_count || transaction.credit_card_charge?.charge?.installments_count;
-    
-    if (modality === 'installment' && installmentsCount && installmentsCount > 1) {
-      return `Cartão ${cardLast4} em ${installmentsCount}x`;
-    }
-    
-    return `Cartão ${cardLast4} à vista`;
-  };
-
-  const getInstallmentInfo = (transaction: any) => {
-    const modality = transaction.modality || transaction.credit_card_charge?.charge?.modality;
-    const installmentsCount = transaction.installments_count || transaction.credit_card_charge?.charge?.installments_count;
-    const totalAmount = transaction.credit_card_charge?.charge?.total_amount || transaction.value || Math.abs(transaction.amount);
-    
-    if (modality === 'installment' && installmentsCount && installmentsCount > 1) {
-      const installmentValue = totalAmount / installmentsCount;
-      return `${installmentsCount}x de ${formatCurrency(installmentValue)}`;
-    }
-    
-    return null;
-  };
-
   const downloadCsv = () => {
     const header = ['Descrição', 'Categoria', 'Data', 'Valor', 'Forma de Pagamento'];
-    const rows = filtered.map((t) => [
-      t.description,
-      t.category,
-      formatDate(t.date as any),
-      `${t.amount < 0 ? '-' : ''}R$ ${formatCurrency(Math.abs(t.amount))}`,
-      formatPaymentMethod(t),
+    const rows = paginatedTransactions.map((row) => [
+      row.description,
+      row.category,
+      row.displayDate,
+      `${row.displayValue < 0 ? '-' : ''}R$ ${formatCurrency(Math.abs(row.displayValue))}`,
+      row.displayPaymentMethod,
     ]);
     const csv = [header, ...rows].map((r) => r.map((c) => `"${String(c).replace('"', '""')}"`).join(';')).join('\n');
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
@@ -708,7 +781,7 @@ export default function TransactionsPage() {
                   ))
                 )}
 
-                {!isLoadingTransactions && !isLoadingSummary && filtered.length === 0 && (
+                {!isLoadingTransactions && !isLoadingSummary && paginatedTransactions.length === 0 && (
                   <TableRow>
                     <TableCell colSpan={6} className="py-10 text-center text-sm text-gray-500 dark:text-gray-400">
                       Nenhuma transação encontrada.
@@ -716,59 +789,96 @@ export default function TransactionsPage() {
                   </TableRow>
                 )}
 
-                {!isLoadingTransactions && !isLoadingSummary && paginatedTransactions.map((t, idx) => {
-                  const isExpense = t.amount < 0;
-                  const transaction: Transaction = {
-                    id: (t as any).originalId || parseInt(t.id),
-                    organization_id: t.organization_id,
-                    type: isExpense ? 'expense' : 'income',
-                    description: t.description,
-                    category: t.category,
-                    value: Math.abs(t.amount),
-                    payment_method: t.payment_method || '',
-                    date: t.date instanceof Date ? t.date.toISOString() : t.date,
-                    tags: t.tags || [],
-                    card_last4: (t as any).card_last4 !== undefined ? (t as any).card_last4 : undefined,
-                    modality: (t as any).modality !== undefined ? (t as any).modality : undefined,
-                    installments_count: (t as any).installments_count !== undefined ? (t as any).installments_count : undefined,
-                    recurring: (t as any).recurring !== undefined ? (t as any).recurring : undefined,
-                    credit_card_charge: (t as any).credit_card_charge,
-                  };
-                  
-                  const installmentInfo = getInstallmentInfo(t);
-                  
+                {!isLoadingTransactions && !isLoadingSummary && paginatedTransactions.map((row, idx) => {
+                  const isExpense = row.displayValue < 0;
+                  const rowKey = row.installment
+                    ? `${row.transactionId}-${row.installment.installment_number}`
+                    : row.transactionId.toString();
+
+                  const card = row.transaction.credit_card_charge?.card;
+                  const paymentMethodCell = row.installment ? (
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="cursor-help underline decoration-dotted decoration-gray-400">
+                            {row.displayPaymentMethod}
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="top" className="max-w-[280px] p-0 border-0 shadow-xl rounded-xl overflow-hidden bg-white dark:bg-gray-900">
+                          <div className="space-y-0">
+                            {card && (
+                              <div className="bg-gradient-to-br from-[#4A56E2]/10 to-[#4A56E2]/5 dark:from-[#4A56E2]/20 dark:to-[#4A56E2]/10 px-4 py-3">
+                                <div className="flex items-center gap-2 mb-2">
+                                  <div className="p-1.5 rounded-lg bg-[#4A56E2]/20 dark:bg-[#4A56E2]/30">
+                                    <CreditCard className="h-4 w-4 text-[#4A56E2] dark:text-[#6B7BFF]" />
+                                  </div>
+                                  <span className="text-xs font-semibold uppercase tracking-wider text-[#4A56E2] dark:text-[#6B7BFF]">Cartão</span>
+                                </div>
+                                <p className="font-semibold text-gray-900 dark:text-gray-100 text-sm">
+                                  {card.brand ? `${card.brand.charAt(0).toUpperCase() + card.brand.slice(1)} ` : ''}****{card.last4}
+                                  {card.description && <span className="text-gray-600 dark:text-gray-400 font-normal"> — {card.description}</span>}
+                                </p>
+                                <p className="text-xs text-gray-600 dark:text-gray-400 mt-1 flex items-center gap-1.5">
+                                  <Calendar className="h-3.5 w-3.5" />
+                                  Vencimento da fatura: dia {card.due_day}
+                                </p>
+                              </div>
+                            )}
+                            <div className="px-4 py-3 space-y-2">
+                              <div className="flex items-center gap-2 mb-2">
+                                <div className="p-1.5 rounded-lg bg-gray-100 dark:bg-gray-800">
+                                  <Receipt className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+                                </div>
+                                <span className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Parcela</span>
+                              </div>
+                              <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-sm">
+                                <span className="text-gray-500 dark:text-gray-400">Compra</span>
+                                <span className="font-medium text-right">{formatDateShort(row.transaction.date)}</span>
+                                <span className="text-gray-500 dark:text-gray-400">Parcela</span>
+                                <span className="font-medium text-right">{row.installment.installment_number} de {row.installment.total_installments}</span>
+                                <span className="text-gray-500 dark:text-gray-400">Vencimento</span>
+                                <span className="font-medium text-right">{formatDateShort(row.installment.due_date)}</span>
+                                <span className="text-gray-500 dark:text-gray-400 flex items-center gap-1">Valor parcela</span>
+                                <span className="font-semibold text-right text-gray-900 dark:text-gray-100">R$ {formatCurrency(row.installment.amount)}</span>
+                                <span className="text-gray-500 dark:text-gray-400 flex items-center gap-1">Valor total</span>
+                                <span className="font-semibold text-right text-[#4A56E2] dark:text-[#6B7BFF]">R$ {formatCurrency(row.transaction.value)}</span>
+                              </div>
+                            </div>
+                          </div>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  ) : (
+                    row.displayPaymentMethod
+                  );
+
                   return (
-                    <TableRow key={t.id} className={idx % 2 === 0 ? 'bg-gray-50' : undefined}>
+                    <TableRow key={rowKey} className={idx % 2 === 0 ? 'bg-gray-50' : undefined}>
                       <TableCell className="font-medium text-gray-900 dark:text-gray-100 max-w-[150px]">
                         <TooltipProvider>
                           <Tooltip>
                             <TooltipTrigger asChild>
-                              <div className="truncate cursor-help" title={t.description}>
-                                {t.description}
+                              <div className="truncate cursor-help" title={row.description}>
+                                {row.description}
                               </div>
                             </TooltipTrigger>
                             <TooltipContent side="top" className="max-w-xs">
-                              <p className="break-words">{t.description}</p>
+                              <p className="break-words">{row.description}</p>
                             </TooltipContent>
                           </Tooltip>
                         </TooltipProvider>
                       </TableCell>
                       <TableCell>
                         <Badge variant="outline" className="rounded-full text-[10px] font-medium px-2 py-0.5 border-gray-200 text-gray-600 dark:border-white/15 dark:text-gray-300">
-                          {t.category}
+                          {row.category}
                         </Badge>
                       </TableCell>
-                      <TableCell className="text-gray-700">{formatDate(t.date as any)}</TableCell>
+                      <TableCell className="text-gray-700">{row.displayDate}</TableCell>
                       <TableCell className="text-gray-700 text-sm">
-                        {formatPaymentMethod(t)}
+                        {paymentMethodCell}
                       </TableCell>
                       <TableCell className={isExpense ? 'text-[#F87171] text-right tabular-nums font-semibold' : 'text-[#10B981] text-right tabular-nums font-semibold'}>
-                        <div className="flex flex-col items-end">
-                          <span>{isExpense ? '-' : '+'}R$ {formatCurrency(Math.abs(t.amount))}</span>
-                          {installmentInfo && (
-                            <span className="text-xs text-gray-500 font-normal mt-0.5">{installmentInfo}</span>
-                          )}
-                        </div>
+                        {isExpense ? '-' : '+'}R$ {formatCurrency(Math.abs(row.displayValue))}
                       </TableCell>
                       <TableCell className="text-right">
                         <div className="flex items-center justify-end gap-2">
@@ -776,7 +886,7 @@ export default function TransactionsPage() {
                             type="button"
                             variant="ghost"
                             size="sm"
-                            onClick={() => handleEdit(transaction)}
+                            onClick={() => handleEdit(row.transaction)}
                             className="h-8 w-8 p-0 hover:bg-blue-50 dark:hover:bg-blue-900/20"
                           >
                             <Edit className="h-4 w-4 text-blue-600 dark:text-blue-400" />
@@ -785,7 +895,7 @@ export default function TransactionsPage() {
                             type="button"
                             variant="ghost"
                             size="sm"
-                            onClick={() => handleDeleteClick(transaction)}
+                            onClick={() => handleDeleteClick(row.transaction)}
                             className="h-8 w-8 p-0 hover:bg-red-50 dark:hover:bg-red-900/20"
                           >
                             <Trash2 className="h-4 w-4 text-red-600 dark:text-red-400" />

--- a/src/pages/transactions.tsx
+++ b/src/pages/transactions.tsx
@@ -48,6 +48,7 @@ export default function TransactionsPage() {
   const [dateRange, setDateRange] = useState<{ from: Date; to: Date } | undefined>(undefined);
   const [category, setCategory] = useState<string>('todas');
   const [paymentMethod, setPaymentMethod] = useState<string>('todas');
+  const [recurring, setRecurring] = useState<'all' | 'recurring' | 'non_recurring'>('all');
   const [sortField, setSortField] = useState<SortField>('date');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [currentPage, setCurrentPage] = useState(1);
@@ -113,6 +114,12 @@ export default function TransactionsPage() {
     return {};
   }, [query]);
 
+  // Preparar filtro de recorrência para a API
+  const apiRecurringFilter = useMemo(() => {
+    if (recurring === 'all') return {};
+    return { recurring: recurring === 'recurring' };
+  }, [recurring]);
+
   // Converter dateRange para string nas queryKeys para evitar recriação de objetos Date
   const dateRangeKey = dateRange?.from && dateRange?.to
     ? `${format(dateRange.from, 'yyyy-MM-dd')}_${format(dateRange.to, 'yyyy-MM-dd')}`
@@ -120,7 +127,7 @@ export default function TransactionsPage() {
 
   // Query para buscar transações paginadas
   const { data: transactionsData, isLoading: isLoadingTransactions } = useQuery({
-    queryKey: ['transactions', activeOrgId, dateRangeKey, type, category, paymentMethod, query, currentPage],
+    queryKey: ['transactions', activeOrgId, dateRangeKey, type, category, paymentMethod, query, recurring, currentPage],
     queryFn: async () => {
       if (!activeOrgId) return null;
       
@@ -131,6 +138,7 @@ export default function TransactionsPage() {
         ...apiCategoryFilter,
         ...apiPaymentMethodFilter,
         ...apiDescriptionFilter,
+        ...(recurring !== 'all' ? apiRecurringFilter : {}),
         page: currentPage,
         limit: ITEMS_PER_PAGE,
       });
@@ -140,7 +148,7 @@ export default function TransactionsPage() {
 
   // Query para buscar estatísticas (KPIs)
   const { data: summaryData, isLoading: isLoadingSummary } = useQuery({
-    queryKey: ['transactions-summary', activeOrgId, dateRangeKey, type, category, paymentMethod, query],
+    queryKey: ['transactions-summary', activeOrgId, dateRangeKey, type, category, paymentMethod, query, recurring],
     queryFn: async () => {
       if (!activeOrgId) return null;
       
@@ -151,6 +159,7 @@ export default function TransactionsPage() {
         ...apiCategoryFilter,
         ...apiPaymentMethodFilter,
         ...apiDescriptionFilter,
+        ...(recurring !== 'all' ? apiRecurringFilter : {}),
       });
     },
     enabled: !!activeOrgId,
@@ -223,9 +232,15 @@ export default function TransactionsPage() {
   }, [paymentMethodsFromTransactions]);
 
   const filtered = useMemo(() => {
-    // A API já aplica todos os filtros, então apenas aplicamos ordenamento no frontend
+    // A API já aplica todos os filtros; aplicar filtro de recorrência no cliente como fallback
+    // (caso a API não suporte o parâmetro recurring)
     let list = [...transactionsWithAmount];
-    
+    if (recurring === 'recurring') {
+      list = list.filter((t) => (t as { recurring?: boolean }).recurring === true);
+    } else if (recurring === 'non_recurring') {
+      list = list.filter((t) => (t as { recurring?: boolean }).recurring !== true);
+    }
+
     // Ordenamento
     if (sortField && sortDirection) {
       list.sort((a, b) => {
@@ -264,7 +279,7 @@ export default function TransactionsPage() {
     }
     
     return list;
-  }, [transactionsWithAmount, sortField, sortDirection]);
+  }, [transactionsWithAmount, recurring, sortField, sortDirection]);
 
   // Estatísticas do período filtrado - usar dados do summary da API
   const stats = useMemo(() => {
@@ -313,7 +328,7 @@ export default function TransactionsPage() {
   // Resetar página quando filtros mudarem
   useEffect(() => {
     setCurrentPage(1);
-  }, [type, dateRange, category, paymentMethod, query]);
+  }, [type, dateRange, category, paymentMethod, query, recurring]);
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {
@@ -541,6 +556,19 @@ export default function TransactionsPage() {
                   {paymentMethods.map((pm) => (
                     <SelectItem key={pm} value={pm}>{pm}</SelectItem>
                   ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <label id="tx-recurring-label" className="mb-1 block text-xs font-medium text-gray-600">Recorrência</label>
+              <Select value={recurring} onValueChange={(v) => setRecurring(v as 'all' | 'recurring' | 'non_recurring')}>
+                <SelectTrigger id="tx-recurring" aria-labelledby="tx-recurring-label" className="rounded-xl h-10 border-[#D1D5DB] bg-white text-[#111827] shadow-sm focus-visible:ring-2 focus-visible:ring-[#4A56E2] focus-visible:ring-offset-1">
+                  <SelectValue placeholder="Recorrência" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Todas</SelectItem>
+                  <SelectItem value="recurring">Apenas recorrentes</SelectItem>
+                  <SelectItem value="non_recurring">Apenas não recorrentes</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -176,6 +176,38 @@ export const handlers = [
         ]);
     }),
 
+    // Consultant endpoints
+    http.get('*/v1/consultant/summary', () => {
+        return HttpResponse.json({
+            total_income: 50000,
+            total_expenses: 32000,
+            balance: 18000,
+            total_transactions: 245,
+            organizations_count: 8,
+            period_start: '2025-01-01',
+            period_end: '2025-01-31',
+        });
+    }),
+    http.get('*/v1/consultant/clients', () => {
+        return HttpResponse.json({
+            total: 2,
+            clients: [
+                {
+                    organization_id: 'org-123',
+                    organization_name: 'Empresa ABC',
+                    role: 'owner',
+                    membership_created_at: '2024-06-15T10:00:00Z',
+                },
+                {
+                    organization_id: 'org-456',
+                    organization_name: 'Empresa XYZ',
+                    role: 'member',
+                    membership_created_at: '2024-08-20T14:30:00Z',
+                },
+            ],
+        });
+    }),
+
     // Financial Impact endpoint
     http.post('*/v1/financial-impact/simulate', () => {
         return HttpResponse.json({

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -563,6 +563,34 @@ export interface UpdateGoalRequest {
   category?: string;
 }
 
+// ===== CONSULTANT =====
+export interface ConsultantSummaryQuery {
+  date_start?: string;
+  date_end?: string;
+}
+
+export interface ConsultantSummaryResponse {
+  total_income: number;
+  total_expenses: number;
+  balance: number;
+  total_transactions: number;
+  organizations_count: number;
+  period_start: string | null;
+  period_end: string | null;
+}
+
+export interface ConsultantClient {
+  organization_id: string;
+  organization_name: string;
+  role: 'owner' | 'member';
+  membership_created_at: string;
+}
+
+export interface ConsultantClientsResponse {
+  total: number;
+  clients: ConsultantClient[];
+}
+
 // ===== SIMULADOR FINANCEIRO =====
 export interface NewCardCommitment {
   card_last4: string; // Últimos 4 dígitos do cartão

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,6 +1,8 @@
 // types/api.ts
 
 // ===== AUTENTICAÇÃO =====
+export type UserRole = 'owner' | 'member' | 'consultant';
+
 export interface LoginRequest {
   email: string;
   password: string;
@@ -10,7 +12,7 @@ export interface LoginResponse {
   token: string;
   user_id: string;
   email: string;
-  role: 'owner' | 'member';
+  role: UserRole;
   subscription: {
     plan: 'free' | 'beta' | 'premium';
     max_organizations: number;
@@ -24,7 +26,7 @@ export interface User {
   email: string;
   first_name?: string | null;
   last_name?: string | null;
-  role: 'owner' | 'member';
+  role: UserRole;
   created_at: string;
   subscription?: {
     plan: 'free' | 'beta' | 'premium';
@@ -234,6 +236,7 @@ export interface ListTransactionsQuery {
   date_end?: string; // ISO date string
   value_min?: number;
   value_max?: number;
+  recurring?: boolean; // Filter for recurring transactions
   page?: number; // Page number (1-indexed, default: 1)
   limit?: number; // Items per page (default: 20, max: 100)
 }
@@ -262,6 +265,7 @@ export interface TransactionsSummaryQuery {
   date_end?: string; // ISO date string (YYYY-MM-DD)
   value_min?: number;
   value_max?: number;
+  recurring?: boolean; // Filter for recurring transactions
 }
 
 export interface PeriodInfo {
@@ -589,6 +593,140 @@ export interface ConsultantClient {
 export interface ConsultantClientsResponse {
   total: number;
   clients: ConsultantClient[];
+}
+
+// Query types for additional consultant endpoints
+export interface ActiveGoalsCountQuery {
+  as_of_date?: string;
+}
+
+export interface TotalCreditCardDebtQuery {
+  as_of_date?: string;
+}
+
+export interface CashFlowQuery {
+  date_start?: string;
+  date_end?: string;
+}
+
+export interface ExpensesByCategoryQuery {
+  date_start?: string;
+  date_end?: string;
+}
+
+export interface IncomeCommitmentQuery {
+  date_start?: string;
+  date_end?: string;
+}
+
+export interface GoalsProgressByTypeQuery {
+  as_of_date?: string;
+}
+
+export interface ClientsAtRiskQuery {
+  as_of_date?: string;
+  limit?: number;
+  gasto_maior_renda_meses?: number;
+  endividamento_max_percent?: number;
+  exigir_reserva_emergencia?: boolean;
+}
+
+// Response types for consultant endpoints
+export interface FinancialHealthIndexResponse {
+  index: number;
+  balance_score: number;
+  debt_score: number;
+  reserve_score: number;
+  total_income: number;
+  total_expenses: number;
+  balance: number;
+  total_debt: number;
+  organizations_count: number;
+  period_start: string;
+  period_end: string;
+  formula_info: string;
+}
+
+export interface ActiveGoalsCountResponse {
+  active_goals_count: number;
+  organizations_count: number;
+  as_of_date: string;
+}
+
+export interface TotalCreditCardDebtResponse {
+  total_debt: number;
+  organizations_count: number;
+  as_of_date: string;
+}
+
+export interface MonthlyCashFlowItem {
+  month: string;
+  year: number;
+  month_number: number;
+  total_income: number;
+  total_expenses: number;
+  balance: number;
+}
+
+export interface CashFlowResponse {
+  monthly_data: MonthlyCashFlowItem[];
+  period_start: string;
+  period_end: string;
+}
+
+export interface CategoryExpenseItem {
+  name: string;
+  total: number;
+  percentage: number;
+}
+
+export interface ExpensesByCategoryResponse {
+  categories: CategoryExpenseItem[];
+  total_expenses: number;
+  period_start: string;
+  period_end: string;
+}
+
+export interface MonthlyIncomeCommitmentItem {
+  month: string;
+  year: number;
+  month_number: number;
+  income_commitment_percent: number;
+  total_income: number;
+  total_card_bills: number;
+}
+
+export interface IncomeCommitmentResponse {
+  monthly_data: MonthlyIncomeCommitmentItem[];
+  period_start: string;
+  period_end: string;
+}
+
+export interface GoalProgressByTypeItem {
+  goal_name: string;
+  avg_progress: number;
+  count: number;
+}
+
+export interface GoalsProgressByTypeResponse {
+  by_type: GoalProgressByTypeItem[];
+  organizations_count: number;
+  as_of_date: string;
+}
+
+export interface ClientAtRiskItem {
+  organization_id: string;
+  organization_name: string;
+  main_situation: string;
+  current_balance: number;
+  last_invoice_status: string;
+  risk_score: number;
+}
+
+export interface ClientsAtRiskResponse {
+  clients: ClientAtRiskItem[];
+  total: number;
+  as_of_date: string;
 }
 
 // ===== SIMULADOR FINANCEIRO =====

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -221,9 +221,19 @@ export interface Transaction {
   recurring?: boolean;
   // Novo campo retornado pelo GET quando payment_method é "Cartão de Crédito" ou "credit_card"
   credit_card_charge?: CreditCardCharge | null;
+  /** Parcelas no range de data (quando a transação aparece por causa do vencimento da parcela) */
+  installment_info?: InstallmentInfo[] | null;
   // Timestamps de criação e atualização
   created_at?: string; // ISO datetime string - timestamp quando a transação foi criada
   updated_at?: string; // ISO datetime string - timestamp quando a transação foi atualizada
+}
+
+/** Info de parcela quando a transação aparece na lista por causa do vencimento no range */
+export interface InstallmentInfo {
+  installment_number: number;
+  total_installments: number;
+  due_date: string; // YYYY-MM-DD
+  amount: number;
 }
 
 export interface ListTransactionsQuery {
@@ -717,6 +727,7 @@ export interface GoalsProgressByTypeResponse {
 export interface ClientAtRiskItem {
   organization_id: string;
   organization_name: string;
+  client_name?: string;
   main_situation: string;
   current_balance: number;
   last_invoice_status: string;


### PR DESCRIPTION
## Summary

- Dashboard consolidado em /consultant com resumo (receitas, despesas, balanço, transações, clientes) e lista de clientes
- Visão dedicada por cliente em /consultant/clients/:organizationId com URLs compartilháveis
- useOrganization prioriza organizationId da URL em rotas de cliente
- Redirecionamento de consultores de / para /consultant
- Breadcrumb, sidebar e tratamento de erros (403, guard para não-consultores)
- RequireOrganization permite consultores sem org própria acessarem /consultant

## Test Plan

- [ ] Login como consultor (user com features multi_org_dashboard/client_list/consolidated_reports) → redireciona para /consultant
- [ ] Dashboard consolidado exibe cards e lista de clientes
- [ ] Clique em cliente navega para /consultant/clients/:id
- [ ] Transações, Relatórios, Cartões, Metas funcionam no contexto do cliente
- [ ] Usuário não-consultor acessando /consultant diretamente → redireciona para /
- [ ] npm run test e npm run check passam

Made with [Cursor](https://cursor.com)